### PR TITLE
Calculate notionals in cpibond constructor

### DIFF
--- a/QLNet/Instruments/Bonds/CPIBond.cs
+++ b/QLNet/Instruments/Bonds/CPIBond.cs
@@ -64,8 +64,8 @@ namespace QLNet
              .withFixedRates(fixedRate)
              .withNotionals(faceAmount)
              .withPaymentAdjustment(paymentConvention);
-            
-            
+
+            calculateNotionalsFromCashflows();
 
             cpiIndex_.registerWith(update);
 


### PR DESCRIPTION
The single `calculateNotionalsFromCashflows();` statement was missing from CPIBond.cs

And I think I correctly based it on Ver-1.4 now. Didn't know I had to edit it here in the pull request.
