### PR TITLE
Enable QL_NEGATIVE_RATES

### DIFF
--- a/QLNet/QLNet.csproj
+++ b/QLNet/QLNet.csproj
@@ -37,7 +37,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;QL_NEGATIVE_RATES</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <AllowUnsafeBlocks>false</AllowUnsafeBlocks>

--- a/QLNet/Termstructures/Yield/Bootstraptraits.cs
+++ b/QLNet/Termstructures/Yield/Bootstraptraits.cs
@@ -121,8 +121,8 @@ namespace QLNet
 			//return 3.0;
 
 #if QL_NEGATIVE_RATES
-                    double dt = c.times()[i] - c.times()[i-1];
-            return c.data()[i-1] *System>.Exp(maxRate * dt);
+            double dt = c.times()[i] - c.times()[i-1];
+            return c.data()[i-1] * Math.Exp(maxRate * dt);
 #else
 			// discounts cannot increase
 			return c.data()[i - 1];
@@ -213,7 +213,7 @@ namespace QLNet
                 
             // no constraints.
             // We choose as min a value very unlikely to be exceeded.
-            return -detail::maxRate;
+            return -maxRate;
 #else
 			return Const.QL_Epsilon;
 #endif


### PR DESCRIPTION
The compiler directive QL_NEGATIVE_RATES is now on by default. 

Refer to http://quantlib.10058.n7.nabble.com/QL-NEGATIVE-RATES-tp15367p15392.html
