### PR TITLE
Fix finite differences implied vol calculation

### DIFF
--- a/QLNet/Pricingengines/vanilla/FDEuropeanEngine.cs
+++ b/QLNet/Pricingengines/vanilla/FDEuropeanEngine.cs
@@ -66,7 +66,7 @@ namespace QLNet {
                                                      results_.value.GetValueOrDefault(),
                                                      results_.delta.GetValueOrDefault(),
                                                      results_.gamma.GetValueOrDefault());
-            results_.additionalResults.Add("priceCurve", prices_);
+            results_.additionalResults["priceCurve"] = prices_;
         }
 
         #region IGenericEngine copy-cat

--- a/QLNet/Pricingengines/vanilla/FDMultiPeriodEngine.cs
+++ b/QLNet/Pricingengines/vanilla/FDMultiPeriodEngine.cs
@@ -166,7 +166,7 @@ namespace QLNet {
             results.value = prices_.valueAtCenter();
             results.delta = prices_.firstDerivativeAtCenter();
             results.gamma = prices_.secondDerivativeAtCenter();
-            results.additionalResults.Add("priceCurve", prices_);
+            results.additionalResults["priceCurve"] = prices_;
         }
     }
 }

--- a/QLNet/Pricingengines/vanilla/FDStepConditionEngine.cs
+++ b/QLNet/Pricingengines/vanilla/FDStepConditionEngine.cs
@@ -108,7 +108,7 @@ namespace QLNet {
             results.gamma = prices_.secondDerivativeAtCenter()
                 - controlPrices_.secondDerivativeAtCenter()
                 + black.gamma(spot);
-            results.additionalResults.Add("priceCurve", prices_);
+            results.additionalResults["priceCurve"] = prices_;
         } 
     }
 }


### PR DESCRIPTION
This fixes the issue discussed here:
http://quantlib.10058.n7.nabble.com/Implied-Volatility-td7280.html#a13812 whereby the code attempts to add rather than overwrite the price curve on subsequent iterations.

This issue is specific to the .Net port of QuantLib.