### PR TITLE
Fix iterative bootstrap to initialize previousData as new separate object

### DIFF
--- a/QLNet/Termstructures/Iterativebootstrap.cs
+++ b/QLNet/Termstructures/Iterativebootstrap.cs
@@ -191,7 +191,7 @@ namespace QLNet
 
          for (int iteration = 0; ; ++iteration)
          {
-            previousData_ = ts_.data_;
+            previousData_ = new List<double>(ts_.data_);
 
             for (int i = 1; i <= alive_; ++i)
             {


### PR DESCRIPTION
previousData should be initialized as a NEW List, else it is just a reference to data_ List and will change when data_ changes.

This fixes the tests in piecewiseyieldcurve