### PR TITLE
Instantiate generic classes using expression tree, instead of new keyword

### DIFF
--- a/QLNet/Cashflows/Cashflowvectors.cs
+++ b/QLNet/Cashflows/Cashflowvectors.cs
@@ -2,18 +2,18 @@
  Copyright (C) 2008, 2009 Siarhei Novik (snovik@gmail.com)
  Copyright (C) 2008 Toyin Akin (toyin_akin@hotmail.com)
  Copyright (C) 2008, 2009 , 2010 Andrea Maggiulli (a.maggiulli@gmail.com)
-  
+
  This file is part of QLNet Project https://github.com/amaggiulli/qlnet
 
  QLNet is free software: you can redistribute it and/or modify it
  under the terms of the QLNet license.  You should have received a
- copy of the license along with this program; if not, license is  
+ copy of the license along with this program; if not, license is
  available online at <http://qlnet.sourceforge.net/License.html>.
-  
+
  QLNet is a based on QuantLib, a free-software/open-source library
  for financial quantitative analysts and developers - http://quantlib.org/
  The QuantLib license is available online at http://quantlib.org/license.shtml.
- 
+
  This program is distributed in the hope that it will be useful, but WITHOUT
  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
  FOR A PARTICULAR PURPOSE.  See the license for more details.
@@ -88,7 +88,7 @@ namespace QLNet {
                                                 start, end, refStart, refEnd));
                 } else {
                     if (Utils.noOption(caps, floors, i)) {
-                        leg.Add(new FloatingCouponType().factory(Utils.Get(nominals, i),
+                        leg.Add(New<FloatingCouponType>.Instance().factory(Utils.Get(nominals, i),
                             paymentDate, start, end,
                             Utils.Get( fixingDays, i, index.fixingDays() ),
                             index,
@@ -97,7 +97,7 @@ namespace QLNet {
                             refStart, refEnd, paymentDayCounter,
                             isInArrears));
                     } else {
-                        leg.Add(new CappedFlooredCouponType().factory(Utils.Get(nominals, i),
+                        leg.Add(New<CappedFlooredCouponType>.Instance().factory(Utils.Get(nominals, i),
                             paymentDate, start, end,
                             Utils.Get( fixingDays, i, index.fixingDays() ),
                             index,
@@ -178,7 +178,7 @@ namespace QLNet {
                                         start, end, refStart, refEnd));
 
                 } else { // floating digital coupon
-                    FloatingCouponType underlying = new FloatingCouponType().factory(
+                    FloatingCouponType underlying = New<FloatingCouponType>.Instance().factory(
                        Utils.Get(nominals, i, 1.0),
                        paymentDate, start, end,
                        Utils.Get(fixingDays, i, index.fixingDays()),
@@ -188,7 +188,7 @@ namespace QLNet {
                        refStart, refEnd,
                        paymentDayCounter, isInArrears) as FloatingCouponType;
 
-                    DigitalCouponType digitalCoupon = new DigitalCouponType().factory(
+                    DigitalCouponType digitalCoupon = New<DigitalCouponType>.Instance().factory(
                      underlying,
                      Utils.toNullable(Utils.Get(callStrikes, i, Double.MinValue)),
                      callPosition,
@@ -206,17 +206,17 @@ namespace QLNet {
             return leg;
         }
 
-        
+
          public static List<CashFlow> OvernightLeg(List<double> nominals,
                                                    Schedule schedule,
                                                    BusinessDayConvention paymentAdjustment,
                                                    OvernightIndex overnightIndex,
                                                    List<double> gearings,
                                                    List<double> spreads,
-                                                   DayCounter paymentDayCounter      
+                                                   DayCounter paymentDayCounter
                                                   )
-        
-       
+
+
          {
             if (nominals.Count == 0) throw new ArgumentException("no nominal given");
 
@@ -229,7 +229,7 @@ namespace QLNet {
             Date paymentDate;
 
             int n = schedule.Count;
-            for (int i=0; i<n-1; ++i) 
+            for (int i=0; i<n-1; ++i)
             {
                refStart = start = schedule.date(i);
                refEnd   =   end = schedule.date(i+1);
@@ -253,14 +253,14 @@ namespace QLNet {
            return leg;
         }
 
-         public static List<CashFlow> yoyInflationLeg(List<double> notionals_, 
-                                                      Schedule schedule_, 
-                                                      BusinessDayConvention paymentAdjustment_, 
-                                                      YoYInflationIndex index_, 
-                                                      List<double> gearings_, 
-                                                      List<double> spreads_, 
+         public static List<CashFlow> yoyInflationLeg(List<double> notionals_,
+                                                      Schedule schedule_,
+                                                      BusinessDayConvention paymentAdjustment_,
+                                                      YoYInflationIndex index_,
+                                                      List<double> gearings_,
+                                                      List<double> spreads_,
                                                       DayCounter paymentDayCounter_,
-                                                      List<double> caps_, 
+                                                      List<double> caps_,
                                                       List<double> floors_ ,
                                                       Calendar paymentCalendar_,
                                                       List<int> fixingDays_,

--- a/QLNet/Math/Interpolations/Loginterpolation.cs
+++ b/QLNet/Math/Interpolations/Loginterpolation.cs
@@ -1,17 +1,17 @@
 /*
  Copyright (C) 2008 Siarhei Novik (snovik@gmail.com)
-  
+
  This file is part of QLNet Project https://github.com/amaggiulli/qlnet
 
  QLNet is free software: you can redistribute it and/or modify it
  under the terms of the QLNet license.  You should have received a
- copy of the license along with this program; if not, license is  
+ copy of the license along with this program; if not, license is
  available online at <http://qlnet.sourceforge.net/License.html>.
-  
+
  QLNet is a based on QuantLib, a free-software/open-source library
  for financial quantitative analysts and developers - http://quantlib.org/
  The QuantLib license is available online at http://quantlib.org/license.shtml.
- 
+
  This program is distributed in the hope that it will be useful, but WITHOUT
  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
  FOR A PARTICULAR PURPOSE.  See the license for more details.
@@ -27,7 +27,7 @@ namespace QLNet {
         private Interpolation interpolation_;
 
         public LogInterpolationImpl(List<double> xBegin, int size, List<double> yBegin)
-           : this(xBegin, size, yBegin, new Interpolator()) { }
+           : this(xBegin, size, yBegin, New<Interpolator>.Instance()) { }
         public LogInterpolationImpl(List<double> xBegin, int size, List<double> yBegin, IInterpolationFactory factory)
             : base(xBegin, size, yBegin) {
             logY_ = new InitializedList<double>(size_);

--- a/QLNet/Math/Interpolations/XABRInterpolation.cs
+++ b/QLNet/Math/Interpolations/XABRInterpolation.cs
@@ -5,13 +5,13 @@
 
  QLNet is free software: you can redistribute it and/or modify it
  under the terms of the QLNet license.  You should have received a
- copy of the license along with this program; if not, license is  
+ copy of the license along with this program; if not, license is
  available online at <http://qlnet.sourceforge.net/License.html>.
-  
+
  QLNet is a based on QuantLib, a free-software/open-source library
  for financial quantitative analysts and developers - http://quantlib.org/
  The QuantLib license is available online at http://quantlib.org/license.shtml.
- 
+
  This program is distributed in the hope that it will be useful, but WITHOUT
  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
  FOR A PARTICULAR PURPOSE.  See the license for more details.
@@ -56,20 +56,20 @@ namespace QLNet
          XABREndCriteria_ = EndCriteria.Type.None;
 
          Utils.QL_REQUIRE( t > 0.0, () => "expiry time must be positive: " + t + " not allowed" );
-         Utils.QL_REQUIRE( _params.Count == new Model().dimension(), () =>
+         Utils.QL_REQUIRE( _params.Count == New<Model>.Instance().dimension(), () =>
                    "wrong number of parameters (" + _params.Count
                                                   + "), should be "
-                                                  + new Model().dimension() );
-         Utils.QL_REQUIRE( paramIsFixed.Count == new Model().dimension(), () =>
+                                                  + New<Model>.Instance().dimension() );
+         Utils.QL_REQUIRE( paramIsFixed.Count == New<Model>.Instance().dimension(), () =>
                    "wrong number of fixed parameters flags (" + paramIsFixed.Count + "), should be "
-                   + new Model().dimension() );
+                   + New<Model>.Instance().dimension() );
 
          for ( int i = 0; i < _params.Count; ++i )
          {
             if ( _params[i] != null )
                paramIsFixed_[i] = paramIsFixed[i];
          }
-         new Model().defaultValues( params_, paramIsFixed_, forward_, t_ );
+         New<Model>.Instance().defaultValues( params_, paramIsFixed_, forward_, t_ );
          updateModelInstance();
       }
 
@@ -77,8 +77,8 @@ namespace QLNet
       {
          // forward might have changed
          Utils.QL_REQUIRE( forward_ > 0.0, () => "forward must be positive: " + forward_ + " not allowed" );
-         modelInstance_ = new Model().instance( t_, forward_, params_ );
-         model_ = new Model();
+         modelInstance_ = New<Model>.Instance().instance( t_, forward_, params_ );
+         model_ = New<Model>.Instance();
       }
 
       /*! Expiry, Forward */
@@ -109,11 +109,11 @@ namespace QLNet
          : base( xBegin, size, yBegin )
       {
           // XABRCoeffHolder<Model>(t, forward, params, paramIsFixed),
-          endCriteria_ = endCriteria; 
+          endCriteria_ = endCriteria;
           optMethod_ = optMethod;
-          errorAccept_ = errorAccept; 
+          errorAccept_ = errorAccept;
           useMaxError_ = useMaxError;
-          maxGuesses_ = maxGuesses; 
+          maxGuesses_ = maxGuesses;
           forward_ = forward;
           vegaWeighted_ = vegaWeighted;
 
@@ -122,14 +122,14 @@ namespace QLNet
             optMethod_ = new LevenbergMarquardt(1e-8, 1e-8, 1e-8);
             // optMethod_ = boost::shared_ptr<OptimizationMethod>(new
             //    Simplex(0.01));
-         if (endCriteria_ == null) 
+         if (endCriteria_ == null)
          {
             endCriteria_ = new EndCriteria(60000, 100, 1e-8, 1e-8, 1e-8);
          }
          coeff_ = new XABRCoeffHolder<Model>( t, forward, _params, paramIsFixed );
          this.coeff_.weights_ = new InitializedList<double>( size, 1.0 / size );
       }
-      
+
       public override void update()
       {
          this.coeff_.updateModelInstance();
@@ -137,7 +137,7 @@ namespace QLNet
          // we should also check that y contains positive values only
 
          // we must update weights if it is vegaWeighted
-         if (vegaWeighted_) 
+         if (vegaWeighted_)
          {
             coeff_.weights_.Clear();
             double weightsSum = 0.0;
@@ -193,7 +193,7 @@ namespace QLNet
 
                 Vector inversedTransformatedGuess = new Vector(coeff_.model_.inverse(guess, coeff_.paramIsFixed_, coeff_.params_, forward_));
 
-                ProjectedCostFunction rainedXABRError = new ProjectedCostFunction(costFunction, inversedTransformatedGuess, 
+                ProjectedCostFunction rainedXABRError = new ProjectedCostFunction(costFunction, inversedTransformatedGuess,
                                                                                   coeff_.paramIsFixed_);
 
                 Vector projectedGuess = new Vector(rainedXABRError.project(inversedTransformatedGuess));
@@ -212,7 +212,7 @@ namespace QLNet
                 tmpInterpolationError = useMaxError_ ? interpolationMaxError()
                                                      : interpolationError();
 
-                if (tmpInterpolationError < bestError) 
+                if (tmpInterpolationError < bestError)
                 {
                     bestError = tmpInterpolationError;
                     bestParameters = result;
@@ -241,7 +241,7 @@ namespace QLNet
       public override double secondDerivative( double d ) { Utils.QL_FAIL( "XABR secondDerivative not implemented" ); return 0; }
 
       // calculate total squared weighted difference (L2 norm)
-      public double interpolationSquaredError()  
+      public double interpolationSquaredError()
       {
          double error, totalError = 0.0;
          for ( int i = 0; i < xBegin_.Count; i++ )
@@ -253,7 +253,7 @@ namespace QLNet
       }
 
       // calculate weighted differences
-      public Vector interpolationErrors( Vector v )  
+      public Vector interpolationErrors( Vector v )
       {
          Vector results = new Vector(xBegin_.Count);
 
@@ -265,14 +265,14 @@ namespace QLNet
 
     }
 
-      public double interpolationError()  
+      public double interpolationError()
       {
         int n = xBegin_.Count;
         double squaredError = interpolationSquaredError();
         return Math.Sqrt(n * squaredError / (n - 1));
     }
 
-      public double interpolationMaxError()  
+      public double interpolationMaxError()
       {
          double error, maxError = Double.MinValue;
 
@@ -292,7 +292,7 @@ namespace QLNet
 
          public override double value( Vector x )
          {
-            Vector y = new Model().direct( x, xabr_.coeff_.paramIsFixed_, xabr_.coeff_.params_, xabr_.forward_ );
+            Vector y = New<Model>.Instance().direct( x, xabr_.coeff_.paramIsFixed_, xabr_.coeff_.params_, xabr_.forward_ );
             for ( int i = 0; i < xabr_.coeff_.params_.Count; ++i )
                xabr_.coeff_.params_[i] = y[i];
             xabr_.coeff_.updateModelInstance();
@@ -301,7 +301,7 @@ namespace QLNet
 
          public override Vector values( Vector x )
          {
-            Vector y = new Model().direct( x, xabr_.coeff_.paramIsFixed_, xabr_.coeff_.params_, xabr_.forward_ );
+            Vector y = New<Model>.Instance().direct( x, xabr_.coeff_.paramIsFixed_, xabr_.coeff_.params_, xabr_.forward_ );
             for ( int i = 0; i < xabr_.coeff_.params_.Count; ++i )
                xabr_.coeff_.params_[i] = y[i];
             xabr_.coeff_.updateModelInstance();

--- a/QLNet/Math/ModifiedBessel.cs
+++ b/QLNet/Math/ModifiedBessel.cs
@@ -1,17 +1,17 @@
 ﻿/*
- Copyright (C) 2008-2016  Andrea Maggiulli (a.maggiulli@gmail.com) 
-  
+ Copyright (C) 2008-2016  Andrea Maggiulli (a.maggiulli@gmail.com)
+
  This file is part of QLNet Project https://github.com/amaggiulli/qlnet
 
  QLNet is free software: you can redistribute it and/or modify it
  under the terms of the QLNet license.  You should have received a
- copy of the license along with this program; if not, license is  
+ copy of the license along with this program; if not, license is
  available online at <http://qlnet.sourceforge.net/License.html>.
-  
+
  QLNet is a based on QuantLib, a free-software/open-source library
  for financial quantitative analysts and developers - http://quantlib.org/
  The QuantLib license is available online at http://quantlib.org/license.shtml.
- 
+
  This program is distributed in the hope that it will be useful, but WITHOUT
  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
  FOR A PARTICULAR PURPOSE.  See the license for more details.
@@ -101,18 +101,18 @@ namespace QLNet
          return modifiedBesselFunction_k_impl<doubleUnweighted, doubleValue>( nu, x );
       }
 
-      public static Complex modifiedBesselFunction_k(double nu, Complex z) 
+      public static Complex modifiedBesselFunction_k(double nu, Complex z)
       {
          return modifiedBesselFunction_k_impl<complexUnweighted, complexValue>( nu, z );
       }
 
-      public static double modifiedBesselFunction_i_exponentiallyWeighted(double nu, double x) 
+      public static double modifiedBesselFunction_i_exponentiallyWeighted(double nu, double x)
       {
          Utils.QL_REQUIRE(x >= 0.0, ()=>"negative argument requires complex version of modifiedBesselFunction");
          return modifiedBesselFunction_i_impl<doubleExponentiallyWeighted, doubleValue>( nu, x );
       }
 
-      public static Complex modifiedBesselFunction_i_exponentiallyWeighted(double nu, Complex z) 
+      public static Complex modifiedBesselFunction_i_exponentiallyWeighted(double nu, Complex z)
       {
          return modifiedBesselFunction_i_impl<complexExponentiallyWeighted, complexValue>( nu, z );
       }
@@ -122,7 +122,7 @@ namespace QLNet
          return modifiedBesselFunction_k_impl<doubleExponentiallyWeighted, doubleValue>( nu, x );
       }
 
-      public static Complex modifiedBesselFunction_k_exponentiallyWeighted(double nu, Complex z) 
+      public static Complex modifiedBesselFunction_k_exponentiallyWeighted(double nu, Complex z)
       {
          return modifiedBesselFunction_k_impl<complexExponentiallyWeighted, complexValue>( nu, z );
       }
@@ -143,7 +143,7 @@ namespace QLNet
                sum += B_k;
                Utils.QL_REQUIRE( ++k < 1000, () => "max iterations exceeded" );
             }
-            return sum * new T().weightSmallX( x );
+            return sum * New<T>.Instance().weightSmallX( x );
          }
          else
          {
@@ -164,10 +164,10 @@ namespace QLNet
                s1 += sign * a_k;
             }
 
-            double i = new I().value();
+            double i = New<I>.Instance().value();
             return 1.0 / Math.Sqrt( 2 * Const.M_PI * x ) *
-               ( new T().weight1LargeX( x ) * s1 +
-               i * Math.Exp( i * nu * Const.M_PI ) * new T().weight2LargeX( x ) * s2 );
+               ( New<T>.Instance().weight1LargeX( x ) * s1 +
+               i * Math.Exp( i * nu * Const.M_PI ) * New<T>.Instance().weight2LargeX( x ) * s2 );
          }
       }
 
@@ -187,7 +187,7 @@ namespace QLNet
                sum += B_k;
                Utils.QL_REQUIRE( ++k < 1000, () => "max iterations exceeded" );
             }
-            return sum * new T().weightSmallX( x );
+            return sum * New<T>.Instance().weightSmallX( x );
          }
          else
          {
@@ -208,10 +208,10 @@ namespace QLNet
                s1 += sign * a_k;
             }
 
-            Complex i = new I().value();
+            Complex i = New<I>.Instance().value();
             return 1.0 / Complex.Sqrt( 2 * Const.M_PI * x ) *
-                ( new T().weight1LargeX( x ) * s1 +
-                 i * Complex.Exp( i * nu * Const.M_PI ) * new T().weight2LargeX( x ) * s2 );
+                ( New<T>.Instance().weight1LargeX( x ) * s1 +
+                 i * Complex.Exp( i * nu * Const.M_PI ) * New<T>.Instance().weight2LargeX( x ) * s2 );
          }
       }
 

--- a/QLNet/Math/integrals/trapezoidintegral.cs
+++ b/QLNet/Math/integrals/trapezoidintegral.cs
@@ -1,17 +1,17 @@
 ﻿/*
  Copyright (C) 2008 Siarhei Novik (snovik@gmail.com)
-  
+
  This file is part of QLNet Project https://github.com/amaggiulli/qlnet
 
  QLNet is free software: you can redistribute it and/or modify it
  under the terms of the QLNet license.  You should have received a
- copy of the license along with this program; if not, license is  
+ copy of the license along with this program; if not, license is
  available online at <http://qlnet.sourceforge.net/License.html>.
-  
+
  QLNet is a based on QuantLib, a free-software/open-source library
  for financial quantitative analysts and developers - http://quantlib.org/
  The QuantLib license is available online at http://quantlib.org/license.shtml.
- 
+
  This program is distributed in the hope that it will be useful, but WITHOUT
  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
  FOR A PARTICULAR PURPOSE.  See the license for more details.
@@ -46,7 +46,7 @@ namespace QLNet {
             // ...and refine it
             int i = 1;
 
-            IntegrationPolicy ip = new IntegrationPolicy();
+            IntegrationPolicy ip = New<IntegrationPolicy>.Instance();
             do {
                 newI = ip.integrate(f, a, b, I, N);
                 N *= ip.nbEvalutions();

--- a/QLNet/Math/randomnumbers/inversecumulativerng.cs
+++ b/QLNet/Math/randomnumbers/inversecumulativerng.cs
@@ -1,17 +1,17 @@
 ﻿/*
  Copyright (C) 2008 Siarhei Novik (snovik@gmail.com)
-  
+
  This file is part of QLNet Project https://github.com/amaggiulli/qlnet
 
  QLNet is free software: you can redistribute it and/or modify it
  under the terms of the QLNet license.  You should have received a
- copy of the license along with this program; if not, license is  
+ copy of the license along with this program; if not, license is
  available online at <http://qlnet.sourceforge.net/License.html>.
-  
+
  QLNet is a based on QuantLib, a free-software/open-source library
  for financial quantitative analysts and developers - http://quantlib.org/
  The QuantLib license is available online at http://quantlib.org/license.shtml.
- 
+
  This program is distributed in the hope that it will be useful, but WITHOUT
  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
  FOR A PARTICULAR PURPOSE.  See the license for more details.
@@ -41,7 +41,7 @@ namespace QLNet {
     */
     public class InverseCumulativeRng<RNG, IC> where RNG : IRNGTraits where IC : IValue, new() {
         private RNG uniformGenerator_;
-        private IC ICND_ = new IC();
+        private IC ICND_ = New<IC>.Instance();
 
         //typedef Sample<double> sample_type;
         //typedef RNG urng_type;

--- a/QLNet/Math/randomnumbers/randomsequencegenerator.cs
+++ b/QLNet/Math/randomnumbers/randomsequencegenerator.cs
@@ -61,7 +61,7 @@ namespace QLNet {
         //public RandomSequenceGenerator(int dimensionality, long seed = 0) {
         public RandomSequenceGenerator(int dimensionality, ulong seed) {
             dimensionality_ = dimensionality;
-            rng_ = (RNG)new RNG().factory(seed);
+            rng_ = (RNG)New<RNG>.Instance().factory(seed);
             sequence_ = new Sample<List<double>>(new InitializedList<double>(dimensionality), 1.0);
             int32Sequence_ = new InitializedList<ulong>(dimensionality);
         }

--- a/QLNet/Math/randomnumbers/rngtraits.cs
+++ b/QLNet/Math/randomnumbers/rngtraits.cs
@@ -1,17 +1,17 @@
 ﻿/*
  Copyright (C) 2008 Siarhei Novik (snovik@gmail.com)
-  
+
  This file is part of QLNet Project https://github.com/amaggiulli/qlnet
 
  QLNet is free software: you can redistribute it and/or modify it
  under the terms of the QLNet license.  You should have received a
- copy of the license along with this program; if not, license is  
+ copy of the license along with this program; if not, license is
  available online at <http://qlnet.sourceforge.net/License.html>.
-  
+
  QLNet is a based on QuantLib, a free-software/open-source library
  for financial quantitative analysts and developers - http://quantlib.org/
  The QuantLib license is available online at http://quantlib.org/license.shtml.
- 
+
  This program is distributed in the hope that it will be useful, but WITHOUT
  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
  FOR A PARTICULAR PURPOSE.  See the license for more details.
@@ -33,7 +33,7 @@ namespace QLNet {
     // random number traits
     public class GenericPseudoRandom<URNG, IC> : IRSG where URNG : IRNGTraits, new() where IC : IValue, new() {
         // data
-        public static IC icInstance = new IC();
+        public static IC icInstance = New<IC>.Instance();
 
         //// typedefs
         //typedef URNG urng_type;
@@ -71,14 +71,14 @@ namespace QLNet {
         //typedef InverseCumulativeRsg<ursg_type,IC> rsg_type;
 
         // data
-        public static IC icInstance = new IC();
+        public static IC icInstance = New<IC>.Instance();
 
         // more traits
         public int allowsErrorEstimate { get { return 0; } }
 
         // factory
         public object make_sequence_generator(int dimension, ulong seed) {
-            URSG g = (URSG)new URSG().factory(dimension, seed);
+            URSG g = (URSG)New<URSG>.Instance().factory(dimension, seed);
             return (icInstance != null ? new InverseCumulativeRsg<URSG, IC>(g, icInstance)
                                        : new InverseCumulativeRsg<URSG, IC>(g));
         }

--- a/QLNet/Math/statistics/convergencestatistics.cs
+++ b/QLNet/Math/statistics/convergencestatistics.cs
@@ -74,7 +74,7 @@ namespace QLNet {
             reset();
         }
 
-        public ConvergenceStatistics() : this(new U()) { }
+        public ConvergenceStatistics() : this(New<U>.Instance()) { }
         public ConvergenceStatistics(U rule) {
             samplingRule_ = rule;
             reset();
@@ -107,7 +107,7 @@ namespace QLNet {
         }
 
         #region wrap-up Stat
-        protected T impl_ = new T();
+        protected T impl_ = New<T>.Instance();
 
         public int samples() { return impl_.samples(); }
         public double mean() { return impl_.mean(); }

--- a/QLNet/Math/statistics/gaussianstatistics.cs
+++ b/QLNet/Math/statistics/gaussianstatistics.cs
@@ -1,17 +1,17 @@
 ﻿/*
  Copyright (C) 2008 Siarhei Novik (snovik@gmail.com)
-  
+
  This file is part of QLNet Project https://github.com/amaggiulli/qlnet
 
  QLNet is free software: you can redistribute it and/or modify it
  under the terms of the QLNet license.  You should have received a
- copy of the license along with this program; if not, license is  
+ copy of the license along with this program; if not, license is
  available online at <http://qlnet.sourceforge.net/License.html>.
-  
+
  QLNet is a based on QuantLib, a free-software/open-source library
  for financial quantitative analysts and developers - http://quantlib.org/
  The QuantLib license is available online at http://quantlib.org/license.shtml.
- 
+
  This program is distributed in the hope that it will be useful, but WITHOUT
  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
  FOR A PARTICULAR PURPOSE.  See the license for more details.
@@ -35,7 +35,7 @@ namespace QLNet {
         }
 
         #region wrap-up Stat
-        protected Stat impl_ = new Stat();
+        protected Stat impl_ = New<Stat>.Instance();
 
         public int samples() { return impl_.samples(); }
         public double mean() { return impl_.mean(); }
@@ -178,7 +178,7 @@ namespace QLNet {
     //typedef GenericGaussianStatistics<GeneralStatistics> GaussianStatistics;
     public class GaussianStatistics : GenericGaussianStatistics<GeneralStatistics> { }
 
-    
+
     //! Helper class for precomputed distributions
     public class StatsHolder : IGeneralStatistics {
         private double mean_, standardDeviation_;

--- a/QLNet/Math/statistics/riskstatistics.cs
+++ b/QLNet/Math/statistics/riskstatistics.cs
@@ -32,7 +32,7 @@ namespace QLNet {
         //typedef typename S::value_type value_type;
 
         #region wrap-up Stat
-        protected Stat impl_ = new Stat();
+        protected Stat impl_ = New<Stat>.Instance();
 
         public int samples() { return impl_.samples(); }
         public double mean() { return impl_.mean(); }

--- a/QLNet/Methods/Finitedifferences/ParallelEvolver.cs
+++ b/QLNet/Methods/Finitedifferences/ParallelEvolver.cs
@@ -51,7 +51,7 @@ namespace QLNet {
         public ParallelEvolver(List<IOperator> L, BoundaryConditionSet bcs) {
             evolvers_ = new List<IMixedScheme>(L.Count);
             for (int i = 0; i < L.Count; i++) {
-                evolvers_.Add(new Evolver().factory(L[i], bcs[i]));
+                evolvers_.Add(New<Evolver>.Instance().factory(L[i], bcs[i]));
             }
         }
 

--- a/QLNet/Methods/Finitedifferences/finitedifferencemodel.cs
+++ b/QLNet/Methods/Finitedifferences/finitedifferencemodel.cs
@@ -1,17 +1,17 @@
 ﻿/*
  Copyright (C) 2008 Siarhei Novik (snovik@gmail.com)
-  
+
  This file is part of QLNet Project https://github.com/amaggiulli/qlnet
 
  QLNet is free software: you can redistribute it and/or modify it
  under the terms of the QLNet license.  You should have received a
- copy of the license along with this program; if not, license is  
+ copy of the license along with this program; if not, license is
  available online at <http://qlnet.sourceforge.net/License.html>.
-  
+
  QLNet is a based on QuantLib, a free-software/open-source library
  for financial quantitative analysts and developers - http://quantlib.org/
  The QuantLib license is available online at http://quantlib.org/license.shtml.
- 
+
  This program is distributed in the hope that it will be useful, but WITHOUT
  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
  FOR A PARTICULAR PURPOSE.  See the license for more details.
@@ -31,7 +31,7 @@ namespace QLNet {
         public FiniteDifferenceModel(object L, object bcs)
             : this(L, bcs, new List<double>()) { }
         public FiniteDifferenceModel(object L, object bcs, List<double> stoppingTimes) {
-            evolver_ = (Evolver)new Evolver().factory(L, bcs);
+            evolver_ = (Evolver)New<Evolver>.Instance().factory(L, bcs);
             stoppingTimes_ = stoppingTimes;
             stoppingTimes_.Sort();
             stoppingTimes_.Distinct();

--- a/QLNet/Methods/Finitedifferences/pde.cs
+++ b/QLNet/Methods/Finitedifferences/pde.cs
@@ -1,17 +1,17 @@
 ﻿/*
  Copyright (C) 2008 Siarhei Novik (snovik@gmail.com)
-  
+
  This file is part of QLNet Project https://github.com/amaggiulli/qlnet
 
  QLNet is free software: you can redistribute it and/or modify it
  under the terms of the QLNet license.  You should have received a
- copy of the license along with this program; if not, license is  
+ copy of the license along with this program; if not, license is
  available online at <http://qlnet.sourceforge.net/License.html>.
-  
+
  QLNet is a based on QuantLib, a free-software/open-source library
  for financial quantitative analysts and developers - http://quantlib.org/
  The QuantLib license is available online at http://quantlib.org/license.shtml.
- 
+
  This program is distributed in the hope that it will be useful, but WITHOUT
  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
  FOR A PARTICULAR PURPOSE.  See the license for more details.
@@ -47,7 +47,7 @@ namespace QLNet {
         private double discount_;
 
         public PdeConstantCoeff(GeneralizedBlackScholesProcess process, double t, double x) {
-            PdeClass pde = (PdeClass)new PdeClass().factory(process);
+            PdeClass pde = (PdeClass)New<PdeClass>.Instance().factory(process);
             diffusion_ = pde.diffusion(t, x);
             drift_ = pde.drift(t, x);
             discount_ = pde.discount(t, x);
@@ -69,7 +69,7 @@ namespace QLNet {
 
         public GenericTimeSetter(Vector grid, GeneralizedBlackScholesProcess process) {
             grid_ = new LogGrid(grid);
-            pde_ = (PdeClass)new PdeClass().factory(process);
+            pde_ = (PdeClass)New<PdeClass>.Instance().factory(process);
         }
 
         public override void setTime(double t, IOperator L) {

--- a/QLNet/New.cs
+++ b/QLNet/New.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.Linq.Expressions;
+
+namespace QLNet
+{
+   public static class New<T>
+      where T : new()
+   {
+      public static readonly Func<T> Instance = Expression.Lambda<Func<T>>(Expression.New(typeof(T))).Compile();
+   }
+}

--- a/QLNet/Patterns/observablevalue.cs
+++ b/QLNet/Patterns/observablevalue.cs
@@ -32,7 +32,7 @@ namespace QLNet {
         private T value_;
         
         public ObservableValue() {
-            value_ = new T();
+            value_ = New<T>.Instance();
         }
 
         public ObservableValue(T t) {

--- a/QLNet/PricingEngine.cs
+++ b/QLNet/PricingEngine.cs
@@ -1,17 +1,17 @@
 /*
  Copyright (C) 2008 Siarhei Novik (snovik@gmail.com)
-  
+
  This file is part of QLNet Project https://github.com/amaggiulli/qlnet
 
  QLNet is free software: you can redistribute it and/or modify it
  under the terms of the QLNet license.  You should have received a
- copy of the license along with this program; if not, license is  
+ copy of the license along with this program; if not, license is
  available online at <http://qlnet.sourceforge.net/License.html>.
-  
+
  QLNet is a based on QuantLib, a free-software/open-source library
  for financial quantitative analysts and developers - http://quantlib.org/
  The QuantLib license is available online at http://quantlib.org/license.shtml.
- 
+
  This program is distributed in the hope that it will be useful, but WITHOUT
  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
  FOR A PARTICULAR PURPOSE.  See the license for more details.
@@ -42,8 +42,8 @@ namespace QLNet {
         where ArgumentsType : IPricingEngineArguments, new()
         where ResultsType : IPricingEngineResults, new()
     {
-        protected ArgumentsType arguments_ = new ArgumentsType();
-        protected ResultsType results_ = new ResultsType();
+        protected ArgumentsType arguments_ = New<ArgumentsType>.Instance();
+        protected ResultsType results_ = New<ResultsType>.Instance();
 
         public IPricingEngineArguments getArguments() { return arguments_; }
         public IPricingEngineResults getResults() { return results_; }
@@ -67,7 +67,7 @@ namespace QLNet {
            eventSource.Raise();
         }
 
-        public virtual void update() { notifyObservers(); } 
+        public virtual void update() { notifyObservers(); }
         #endregion
     }
 

--- a/QLNet/Pricingengines/asian/mc_discr_arith_av_price.cs
+++ b/QLNet/Pricingengines/asian/mc_discr_arith_av_price.cs
@@ -204,7 +204,7 @@ namespace QLNet
         public MakeMCDiscreteArithmeticAPEngine<RNG, S> withTolerance(double tolerance)
         {
            Utils.QL_REQUIRE( samples_ == null, () => "number of samples already set" );
-            if ((new RNG().allowsErrorEstimate == 0))
+            if ((New<RNG>.Instance().allowsErrorEstimate == 0))
                 throw new ApplicationException("chosen random generator policy " +
                                                "does not allow an error estimate");
             tolerance_ = tolerance;

--- a/QLNet/Pricingengines/asian/mc_discr_arith_av_strike.cs
+++ b/QLNet/Pricingengines/asian/mc_discr_arith_av_strike.cs
@@ -148,7 +148,7 @@ namespace QLNet {
         {
 
            Utils.QL_REQUIRE( samples_ == null, () => "number of samples already set" );
-            if ((new RNG().allowsErrorEstimate == 0))
+            if ((New<RNG>.Instance().allowsErrorEstimate == 0))
                 throw new ApplicationException("chosen random generator policy " +
                                                "does not allow an error estimate");
             tolerance_ = tolerance;

--- a/QLNet/Pricingengines/asian/mc_discr_geom_av_price.cs
+++ b/QLNet/Pricingengines/asian/mc_discr_geom_av_price.cs
@@ -181,7 +181,7 @@ namespace QLNet
 
         public MakeMCDiscreteGeometricAPEngine<RNG, S> withTolerance(double tolerance){
            Utils.QL_REQUIRE( samples_ == null, () => "number of samples already set" );
-            if ((new RNG().allowsErrorEstimate == 0))
+            if ((New<RNG>.Instance().allowsErrorEstimate == 0))
                 throw new ApplicationException("chosen random generator policy " +
                                                "does not allow an error estimate");
             tolerance_ = tolerance;

--- a/QLNet/Pricingengines/asian/mcdiscreteasianengine.cs
+++ b/QLNet/Pricingengines/asian/mcdiscreteasianengine.cs
@@ -76,7 +76,7 @@ namespace QLNet
         public void calculate() {
             base.calculate(requiredTolerance_,requiredSamples_,maxSamples_);
             results_.value = this.mcModel_.sampleAccumulator().mean();
-            if (new RNG().allowsErrorEstimate!=0)
+            if (New<RNG>.Instance().allowsErrorEstimate!=0)
             results_.errorEstimate =
                 this.mcModel_.sampleAccumulator().errorEstimate();
         }

--- a/QLNet/Pricingengines/mclongstaffschwartzengine.cs
+++ b/QLNet/Pricingengines/mclongstaffschwartzengine.cs
@@ -1,18 +1,18 @@
 ﻿/*
  Copyright (C) 2008 Siarhei Novik (snovik@gmail.com)
  Copyright (C) 2008-2016 Andrea Maggiulli (a.maggiulli@gmail.com)
-  
+
  This file is part of QLNet Project https://github.com/amaggiulli/qlnet
 
  QLNet is free software: you can redistribute it and/or modify it
  under the terms of the QLNet license.  You should have received a
- copy of the license along with this program; if not, license is  
+ copy of the license along with this program; if not, license is
  available online at <http://qlnet.sourceforge.net/License.html>.
-  
+
  QLNet is a based on QuantLib, a free-software/open-source library
  for financial quantitative analysts and developers - http://quantlib.org/
  The QuantLib license is available online at http://quantlib.org/license.shtml.
- 
+
  This program is distributed in the hope that it will be useful, but WITHOUT
  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
  FOR A PARTICULAR PURPOSE.  See the license for more details.
@@ -48,7 +48,7 @@ namespace QLNet
                                            ulong seed,
                                            int nCalibrationSamples ) :
          base( process, timeSteps, timeStepsPerYear, brownianBridge, antitheticVariate, controlVariate,
-               requiredSamples, requiredTolerance, maxSamples, seed, nCalibrationSamples ) 
+               requiredSamples, requiredTolerance, maxSamples, seed, nCalibrationSamples )
       {}
    }
 
@@ -79,16 +79,16 @@ namespace QLNet
       protected LongstaffSchwartzPathPricer<IPath> pathPricer_;
 
 
-      protected MCLongstaffSchwartzEngine( StochasticProcess process, 
-                                           int? timeSteps, 
+      protected MCLongstaffSchwartzEngine( StochasticProcess process,
+                                           int? timeSteps,
                                            int? timeStepsPerYear,
-                                           bool brownianBridge, 
-                                           bool antitheticVariate, 
+                                           bool brownianBridge,
+                                           bool antitheticVariate,
                                            bool controlVariate,
-                                           int? requiredSamples, 
-                                           double? requiredTolerance, 
+                                           int? requiredSamples,
+                                           double? requiredTolerance,
                                            int? maxSamples,
-                                           ulong seed, 
+                                           ulong seed,
                                            int? nCalibrationSamples )
          : base( antitheticVariate, controlVariate )
       {
@@ -118,14 +118,14 @@ namespace QLNet
       public virtual void calculate()
       {
          pathPricer_ = lsmPathPricer();
-         mcModel_ = new MonteCarloModel<MC, RNG, S>( pathGenerator(), pathPricer_, new S(), antitheticVariate_ );
+         mcModel_ = new MonteCarloModel<MC, RNG, S>( pathGenerator(), pathPricer_, New<S>.Instance(), antitheticVariate_ );
 
          mcModel_.addSamples( nCalibrationSamples_ );
          pathPricer_.calibrate();
 
          base.calculate( requiredTolerance_, requiredSamples_, maxSamples_ );
          results_.value = mcModel_.sampleAccumulator().mean();
-         if ( new RNG().allowsErrorEstimate != 0 )
+         if ( New<RNG>.Instance().allowsErrorEstimate != 0 )
          {
             results_.errorEstimate = mcModel_.sampleAccumulator().errorEstimate();
          }
@@ -160,7 +160,7 @@ namespace QLNet
       {
          int dimensions = process_.factors();
          TimeGrid grid = timeGrid();
-         IRNG generator = (IRNG)new RNG().make_sequence_generator( dimensions * ( grid.size() - 1 ), seed_ );
+         IRNG generator = (IRNG)New<RNG>.Instance().make_sequence_generator( dimensions * ( grid.size() - 1 ), seed_ );
          if ( typeof( MC ) == typeof( SingleVariate ) )
             return new PathGenerator<IRNG>( process_, grid, generator, brownianBridge_ );
          else

--- a/QLNet/Pricingengines/mcsimulation.cs
+++ b/QLNet/Pricingengines/mcsimulation.cs
@@ -1,18 +1,18 @@
 ﻿/*
  Copyright (C) 2008 Siarhei Novik (snovik@gmail.com)
  Copyright (C) 2008-2016 Andrea Maggiulli (a.maggiulli@gmail.com)
-  
+
  This file is part of QLNet Project https://github.com/amaggiulli/qlnet
 
  QLNet is free software: you can redistribute it and/or modify it
  under the terms of the QLNet license.  You should have received a
- copy of the license along with this program; if not, license is  
+ copy of the license along with this program; if not, license is
  available online at <http://qlnet.sourceforge.net/License.html>.
-  
+
  QLNet is a based on QuantLib, a free-software/open-source library
  for financial quantitative analysts and developers - http://quantlib.org/
  The QuantLib license is available online at http://quantlib.org/license.shtml.
- 
+
  This program is distributed in the hope that it will be useful, but WITHOUT
  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
  FOR A PARTICULAR PURPOSE.  See the license for more details.
@@ -111,12 +111,12 @@ namespace QLNet
 
             IPathGenerator<IRNG> controlPG = this.controlPathGenerator();
 
-            this.mcModel_ = new MonteCarloModel<MC, RNG, S>( pathGenerator(), pathPricer(), new S(), antitheticVariate_,
+            this.mcModel_ = new MonteCarloModel<MC, RNG, S>( pathGenerator(), pathPricer(), New<S>.Instance(), antitheticVariate_,
                                                           controlPP, controlVariateValue.Value, controlPG );
          }
          else
          {
-            this.mcModel_ = new MonteCarloModel<MC, RNG, S>( pathGenerator(), pathPricer(), new S(), antitheticVariate_ );
+            this.mcModel_ = new MonteCarloModel<MC, RNG, S>( pathGenerator(), pathPricer(), New<S>.Instance(), antitheticVariate_ );
          }
 
          if ( requiredTolerance != null )

--- a/QLNet/Pricingengines/vanilla/FDConditions.cs
+++ b/QLNet/Pricingengines/vanilla/FDConditions.cs
@@ -1,17 +1,17 @@
 ﻿/*
  Copyright (C) 2008 Siarhei Novik (snovik@gmail.com)
-  
+
  This file is part of QLNet Project https://github.com/amaggiulli/qlnet
 
  QLNet is free software: you can redistribute it and/or modify it
  under the terms of the QLNet license.  You should have received a
- copy of the license along with this program; if not, license is  
+ copy of the license along with this program; if not, license is
  available online at <http://qlnet.sourceforge.net/License.html>.
-  
+
  QLNet is a based on QuantLib, a free-software/open-source library
  for financial quantitative analysts and developers - http://quantlib.org/
  The QuantLib license is available online at http://quantlib.org/license.shtml.
- 
+
  This program is distributed in the hope that it will be useful, but WITHOUT
  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
  FOR A PARTICULAR PURPOSE.  See the license for more details.
@@ -61,7 +61,7 @@ namespace QLNet {
         public FDConditionTemplate(GeneralizedBlackScholesProcess process, int timeSteps, int gridPoints, bool timeDependent)
             : base(process, timeSteps, gridPoints, timeDependent) {
             // init engine
-            engine_ = (baseEngine)new baseEngine().factory(process, timeSteps, gridPoints, timeDependent);
+            engine_ = (baseEngine)New<baseEngine>.Instance().factory(process, timeSteps, gridPoints, timeDependent);
         }
     }
 

--- a/QLNet/Pricingengines/vanilla/FDVanillaEngine.cs
+++ b/QLNet/Pricingengines/vanilla/FDVanillaEngine.cs
@@ -1,18 +1,18 @@
 ﻿/*
  Copyright (C) 2008 Siarhei Novik (snovik@gmail.com)
  Copyright (C) 2008-2013  Andrea Maggiulli (a.maggiulli@gmail.com)
-  
+
  This file is part of QLNet Project https://github.com/amaggiulli/qlnet
 
  QLNet is free software: you can redistribute it and/or modify it
  under the terms of the QLNet license.  You should have received a
- copy of the license along with this program; if not, license is  
+ copy of the license along with this program; if not, license is
  available online at <http://qlnet.sourceforge.net/License.html>.
-  
+
  QLNet is a based on QuantLib, a free-software/open-source library
  for financial quantitative analysts and developers - http://quantlib.org/
  The QuantLib license is available online at http://quantlib.org/license.shtml.
- 
+
  This program is distributed in the hope that it will be useful, but WITHOUT
  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
  FOR A PARTICULAR PURPOSE.  See the license for more details.
@@ -46,7 +46,7 @@ namespace QLNet {
 
         // required for generics and template iheritance
         public FDVanillaEngine() { }
-        // this should be defined as new in each deriving class which use template iheritance 
+        // this should be defined as new in each deriving class which use template iheritance
         // in order to return a proper class to wrap
         public virtual FDVanillaEngine factory(GeneralizedBlackScholesProcess process,
                                        int timeSteps, int gridPoints, bool timeDependent) {
@@ -94,7 +94,7 @@ namespace QLNet {
             // ensure strike is included in the grid
             StrikedTypePayoff striked_payoff = payoff_ as StrikedTypePayoff;
             if (striked_payoff == null) return;
-            
+
             double requiredGridValue = striked_payoff.strike();
 
             if(sMin_ > requiredGridValue/safetyZoneFactor_){
@@ -169,7 +169,7 @@ namespace QLNet {
 
         //public FDEngineAdapter(GeneralizedBlackScholesProcess process, Size timeSteps=100, Size gridPoints=100, bool timeDependent = false)
         public FDEngineAdapter(GeneralizedBlackScholesProcess process, int timeSteps, int gridPoints, bool timeDependent) {
-            optionBase = (Base)new Base().factory(process, timeSteps, gridPoints, timeDependent);
+            optionBase = (Base)New<Base>.Instance().factory(process, timeSteps, gridPoints, timeDependent);
             process.registerWith(update);
         }
 
@@ -181,7 +181,7 @@ namespace QLNet {
 
         #region IGenericEngine wrap-up
         // we do not need to register with the wrapped engine because all we need is containers for parameters and results
-        protected IGenericEngine engine_ = new Engine();    
+        protected IGenericEngine engine_ = New<Engine>.Instance();
 
         public IPricingEngineArguments getArguments() { return engine_.getArguments(); }
         public IPricingEngineResults getResults() { return engine_.getResults(); }

--- a/QLNet/Pricingengines/vanilla/MCEuropeanHestonEngine.cs
+++ b/QLNet/Pricingengines/vanilla/MCEuropeanHestonEngine.cs
@@ -98,7 +98,7 @@ namespace QLNet
        public MakeMCEuropeanHestonEngine<RNG, S> withAbsoluteTolerance( double tolerance )
        {
           Utils.QL_REQUIRE(samples_ == null,()=> "number of samples already set");
-          Utils.QL_REQUIRE( new RNG().allowsErrorEstimate != 0, () => "chosen random generator policy does not allow an error estimate" );
+          Utils.QL_REQUIRE( New<RNG>.Instance().allowsErrorEstimate != 0, () => "chosen random generator policy does not allow an error estimate" );
           tolerance_ = tolerance;
           return this;   
        }

--- a/QLNet/Pricingengines/vanilla/MCHestonHullWhiteEngine.cs
+++ b/QLNet/Pricingengines/vanilla/MCHestonHullWhiteEngine.cs
@@ -157,7 +157,7 @@ namespace QLNet
       public MakeMCHestonHullWhiteEngine<RNG, S> withAbsoluteTolerance( double tolerance )
       {
          Utils.QL_REQUIRE(samples_ == null,()=> "number of samples already set");
-         Utils.QL_REQUIRE( new RNG().allowsErrorEstimate != 0, () => 
+         Utils.QL_REQUIRE( New<RNG>.Instance().allowsErrorEstimate != 0, () => 
             "chosen random generator policy does not allow an error estimate" );
          tolerance_ = tolerance;
          return this;

--- a/QLNet/Pricingengines/vanilla/binomialengine.cs
+++ b/QLNet/Pricingengines/vanilla/binomialengine.cs
@@ -74,7 +74,7 @@ namespace QLNet {
 
             TimeGrid grid = new TimeGrid(maturity, timeSteps_);
 
-            T tree = new T().factory(bs, maturity, timeSteps_, payoff.strike());
+            T tree = New<T>.Instance().factory(bs, maturity, timeSteps_, payoff.strike());
 
             BlackScholesLattice<T> lattice = new BlackScholesLattice<T>(tree, r, maturity, timeSteps_);
 

--- a/QLNet/Pricingengines/vanilla/mcamericanengine.cs
+++ b/QLNet/Pricingengines/vanilla/mcamericanengine.cs
@@ -227,7 +227,7 @@ namespace QLNet
       public MakeMCAmericanEngine<RNG, S> withAbsoluteTolerance( double tolerance )
       {
          Utils.QL_REQUIRE(samples_ == null,()=> "number of samples already set");
-         Utils.QL_REQUIRE( new RNG().allowsErrorEstimate != 0, () => "chosen random generator policy does not allow an error estimate" );
+         Utils.QL_REQUIRE( New<RNG>.Instance().allowsErrorEstimate != 0, () => "chosen random generator policy does not allow an error estimate" );
 
          tolerance_ = tolerance;
          return this;

--- a/QLNet/Pricingengines/vanilla/mceuropeanengine.cs
+++ b/QLNet/Pricingengines/vanilla/mceuropeanengine.cs
@@ -103,7 +103,7 @@ namespace QLNet
       public MakeMCEuropeanEngine<RNG, S> withAbsoluteTolerance( double tolerance )
       {
          Utils.QL_REQUIRE( samples_ == null, () => "number of samples already set" );
-         Utils.QL_REQUIRE( new RNG().allowsErrorEstimate != 0, () =>
+         Utils.QL_REQUIRE( New<RNG>.Instance().allowsErrorEstimate != 0, () =>
             "chosen random generator policy does not allow an error estimate" );
          tolerance_ = tolerance;
          return this;

--- a/QLNet/Pricingengines/vanilla/mcvanillaengine.cs
+++ b/QLNet/Pricingengines/vanilla/mcvanillaengine.cs
@@ -91,7 +91,7 @@ namespace QLNet
       {
          base.calculate( requiredTolerance_, requiredSamples_, maxSamples_ );
          results_.value = mcModel_.sampleAccumulator().mean();
-         if ( new RNG().allowsErrorEstimate != 0 )
+         if ( New<RNG>.Instance().allowsErrorEstimate != 0 )
             results_.errorEstimate = mcModel_.sampleAccumulator().errorEstimate();
       }
 
@@ -120,7 +120,7 @@ namespace QLNet
       {
          int dimensions = process_.factors();
          TimeGrid grid = timeGrid();
-         IRNG generator = (IRNG)new RNG().make_sequence_generator( dimensions * ( grid.size() - 1 ), seed_ );
+         IRNG generator = (IRNG)New<RNG>.Instance().make_sequence_generator( dimensions * ( grid.size() - 1 ), seed_ );
          if ( typeof( MC ) == typeof( SingleVariate ) )
             return new PathGenerator<IRNG>( process_, grid, generator, brownianBridge_ );
          else

--- a/QLNet/QLNet.csproj
+++ b/QLNet/QLNet.csproj
@@ -390,6 +390,7 @@
     <Compile Include="Models\Shortrate\twofactormodel.cs" />
     <Compile Include="Models\Shortrate\Twofactorsmodels\g2.cs" />
     <Compile Include="Money.cs" />
+    <Compile Include="New.cs" />
     <Compile Include="numericalmethod.cs" />
     <Compile Include="Option.cs" />
     <Compile Include="Patterns\LazyObject.cs" />

--- a/QLNet/Termstructures/Credit/InterpolatedHazardRateCurve.cs
+++ b/QLNet/Termstructures/Credit/InterpolatedHazardRateCurve.cs
@@ -34,7 +34,7 @@ namespace QLNet
 			data_ = hazardRates;
 
 			if ( interpolator == null )
-				interpolator_ = new Interpolator();
+				interpolator_ = New<Interpolator>.Instance();
 			else
 				interpolator_ = interpolator;
 
@@ -49,7 +49,7 @@ namespace QLNet
 			times_ = new List<double>();
 			data_ = hazardRates;
 			if ( interpolator == null )
-				interpolator_ = new Interpolator();
+				interpolator_ = New<Interpolator>.Instance();
 			else
 				interpolator_ = interpolator;
 			initialize();
@@ -60,7 +60,7 @@ namespace QLNet
 		{
 			dates_ = dates;
 			if ( interpolator == null )
-				interpolator_ = new Interpolator();
+				interpolator_ = New<Interpolator>.Instance();
 			else
 				interpolator_ = interpolator;
 			initialize();

--- a/QLNet/Termstructures/Inflation/InterpolatedZeroInflationCurve.cs
+++ b/QLNet/Termstructures/Inflation/InterpolatedZeroInflationCurve.cs
@@ -34,7 +34,7 @@ namespace QLNet
          times_ = new List<double>();
          dates_ = dates;
          data_ = rates;
-         interpolator_ = interpolator ?? new Interpolator();
+         interpolator_ = interpolator ?? New<Interpolator>.Instance();
 
          Utils.QL_REQUIRE(dates_.Count > 1, () => "too few dates: " + dates_.Count);
 
@@ -175,7 +175,7 @@ namespace QLNet
                                      Interpolator interpolator = default(Interpolator))
          : base( referenceDate, calendar, dayCounter, baseZeroRate, lag, frequency, indexIsInterpolated, yTS )
       {
-         interpolator_ = interpolator ?? new Interpolator();
+         interpolator_ = interpolator ?? New<Interpolator>.Instance();
       }
 
    }

--- a/QLNet/Termstructures/Inflation/PiecewiseYoYInflationCurve.cs
+++ b/QLNet/Termstructures/Inflation/PiecewiseYoYInflationCurve.cs
@@ -5,13 +5,13 @@
 
  QLNet is free software: you can redistribute it and/or modify it
  under the terms of the QLNet license.  You should have received a
- copy of the license along with this program; if not, license is  
+ copy of the license along with this program; if not, license is
  available online at <http://qlnet.sourceforge.net/License.html>.
-  
+
  QLNet is a based on QuantLib, a free-software/open-source library
  for financial quantitative analysts and developers - http://quantlib.org/
  The QuantLib license is available online at http://quantlib.org/license.shtml.
- 
+
  This program is distributed in the hope that it will be useful, but WITHOUT
  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
  FOR A PARTICULAR PURPOSE.  See the license for more details.
@@ -154,7 +154,7 @@ namespace QLNet
 		{
 			get
 			{
-				//todo edem 
+				//todo edem
 				List<BootstrapHelper<YoYInflationTermStructure>> instruments = new List<BootstrapHelper<YoYInflationTermStructure>>();
 				_instruments_.ForEach( x => instruments.Add( x ) );
 				return instruments;
@@ -228,16 +228,16 @@ namespace QLNet
 			_instruments_ = instruments;
 			accuracy_ = accuracy;
 			if ( bootstrap == null )
-				bootstrap_ = new Bootstrap();
+				bootstrap_ = New<Bootstrap>.Instance();
 			else
 				bootstrap_ = bootstrap;
 
 			if ( i == null )
-				interpolator_ = new Interpolator();
+				interpolator_ = New<Interpolator>.Instance();
 			else
 				interpolator_ = i;
 
-			_traits_ = new Traits();
+			_traits_ = New<Traits>.Instance();
 			bootstrap_.setup( this );
 
 		}

--- a/QLNet/Termstructures/Inflation/PiecewiseZeroInflationCurve.cs
+++ b/QLNet/Termstructures/Inflation/PiecewiseZeroInflationCurve.cs
@@ -6,13 +6,13 @@
 
  QLNet is free software: you can redistribute it and/or modify it
  under the terms of the QLNet license.  You should have received a
- copy of the license along with this program; if not, license is  
+ copy of the license along with this program; if not, license is
  available online at <http://qlnet.sourceforge.net/License.html>.
-  
+
  QLNet is a based on QuantLib, a free-software/open-source library
  for financial quantitative analysts and developers - http://quantlib.org/
  The QuantLib license is available online at http://quantlib.org/license.shtml.
- 
+
  This program is distributed in the hope that it will be useful, but WITHOUT
  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
  FOR A PARTICULAR PURPOSE.  See the license for more details.
@@ -155,7 +155,7 @@ namespace QLNet
 		{
 			get
 			{
-				//todo edem 
+				//todo edem
 				List<BootstrapHelper<ZeroInflationTermStructure>> instruments = new List<BootstrapHelper<ZeroInflationTermStructure>>();
 				_instruments_.ForEach( x => instruments.Add( x ) );
 				return instruments;
@@ -229,16 +229,16 @@ namespace QLNet
 			_instruments_ = instruments;
 			accuracy_ = accuracy;
 			if ( bootstrap == null )
-				bootstrap_ = new Bootstrap();
+				bootstrap_ = New<Bootstrap>.Instance();
 			else
 				bootstrap_ = bootstrap;
 
 			if ( i == null )
-				interpolator_ = new Interpolator();
+				interpolator_ = New<Interpolator>.Instance();
 			else
 				interpolator_ = i;
 
-			_traits_ = new Traits();
+			_traits_ = New<Traits>.Instance();
 			bootstrap_.setup( this );
 
 		}

--- a/QLNet/Termstructures/Iterativebootstrap.cs
+++ b/QLNet/Termstructures/Iterativebootstrap.cs
@@ -2,18 +2,18 @@
  Copyright (C) 2008 Siarhei Novik (snovik@gmail.com)
  Copyright (C) 2008-2016  Andrea Maggiulli (a.maggiulli@gmail.com)
  Copyright (C) 2014 Edem Dawui (edawui@gmail.com)
- 
+
  This file is part of QLNet Project https://github.com/amaggiulli/qlnet
 
  QLNet is free software: you can redistribute it and/or modify it
  under the terms of the QLNet license.  You should have received a
- copy of the license along with this program; if not, license is  
+ copy of the license along with this program; if not, license is
  available online at <http://qlnet.sourceforge.net/License.html>.
-  
+
  QLNet is a based on QuantLib, a free-software/open-source library
  for financial quantitative analysts and developers - http://quantlib.org/
  The QuantLib license is available online at http://quantlib.org/license.shtml.
- 
+
  This program is distributed in the hope that it will be useful, but WITHOUT
  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
  FOR A PARTICULAR PURPOSE.  See the license for more details.
@@ -21,7 +21,7 @@
 using System;
 using System.Collections.Generic;
 
-namespace QLNet 
+namespace QLNet
 {
 	public interface IBootStrap<T>
 	{
@@ -59,7 +59,7 @@ namespace QLNet
 
 		public IterativeBootstrap()
 		{
-			ts_ = new T();
+			ts_ = New<T>.Instance();
 			initialized_ = false;
 			validCurve_ = false;
 		}
@@ -80,8 +80,8 @@ namespace QLNet
 						  "not enough alive instruments: " + alive_ +
 						  " provided, " + ( ts_.interpolator_.requiredPoints - 1 ) +
 						  " required" );
-         
-         
+
+
          if ( ts_.dates_ == null )
          {
             ts_.dates_ = new InitializedList<Date>( alive_ + 1 );
@@ -95,7 +95,7 @@ namespace QLNet
 
          List<Date> dates = ts_.dates_;
          List<double> times = ts_.times_;
-         
+
 
 			errors_ = new List<BootstrapError<T, U>>( alive_ + 1 );
 			dates[0] = firstDate ;
@@ -141,7 +141,7 @@ namespace QLNet
 
 		}
 
-		public void setup(T ts) 
+		public void setup(T ts)
 		{
          ts_ = ts;
 
@@ -157,7 +157,7 @@ namespace QLNet
          loopRequired_ = ts_.interpolator_.global;
       }
 
-      public void calculate() 
+      public void calculate()
 		{
 			// we might have to call initialize even if the curve is initialized
 			// and not moving, just because helpers might be date relative and change
@@ -179,7 +179,7 @@ namespace QLNet
 				// This call creates helpers, and removes "const".
 				// There is a significant interaction with observability.
 				ts_.setTermStructure( ts_.instruments_[j] );
-			} 
+			}
 
 			List<double> times = ts_.times_;
             List<double> data = ts_.data_;
@@ -206,7 +206,7 @@ namespace QLNet
                   guess = max - (max - min) / 5.0;
                else if (guess <= min)
                   guess = min + (max - min) / 5.0;
-                    
+
                // extend interpolation if needed
                if (!validData)
                {

--- a/QLNet/Termstructures/Volatility/equityfx/BlackVarianceCurve.cs
+++ b/QLNet/Termstructures/Volatility/equityfx/BlackVarianceCurve.cs
@@ -93,7 +93,7 @@ namespace QLNet {
         }
 
         public void setInterpolation<Interpolator>() where Interpolator : IInterpolationFactory, new() {
-            setInterpolation<Interpolator>(new Interpolator());
+            setInterpolation<Interpolator>(New<Interpolator>.Instance());
         }
         public void setInterpolation<Interpolator>(Interpolator i) where Interpolator : IInterpolationFactory, new() {
             varianceCurve_ = i.interpolate(times_, times_.Count, variances_);

--- a/QLNet/Termstructures/Volatility/equityfx/BlackVarianceSurface.cs
+++ b/QLNet/Termstructures/Volatility/equityfx/BlackVarianceSurface.cs
@@ -138,7 +138,7 @@ namespace QLNet
 
       public void setInterpolation<Interpolator>() where Interpolator : IInterpolationFactory2D, new()
       {
-         setInterpolation<Interpolator>(new Interpolator());
+         setInterpolation<Interpolator>(New<Interpolator>.Instance());
       }
 
       public void setInterpolation<Interpolator>(Interpolator i) where Interpolator : IInterpolationFactory2D, new()

--- a/QLNet/Termstructures/Yield/DiscountCurve.cs
+++ b/QLNet/Termstructures/Yield/DiscountCurve.cs
@@ -82,7 +82,7 @@ namespace QLNet
                                        Interpolator interpolator = default(Interpolator))
          : base(dayCounter, jumps, jumpDates)
       {
-         interpolator_ = interpolator ?? new Interpolator();
+         interpolator_ = interpolator ?? New<Interpolator>.Instance();
       }
 
       public InterpolatedDiscountCurve(Date referenceDate,
@@ -92,7 +92,7 @@ namespace QLNet
                                        Interpolator interpolator = default(Interpolator))
          : base(referenceDate, null, dayCounter, jumps, jumpDates)
       {
-         interpolator_ = interpolator ?? new Interpolator();
+         interpolator_ = interpolator ?? New<Interpolator>.Instance();
       }
 
       public InterpolatedDiscountCurve(int settlementDays,
@@ -103,7 +103,7 @@ namespace QLNet
                                        Interpolator interpolator = default(Interpolator))
          : base(settlementDays, calendar, dayCounter, jumps, jumpDates)
       {
-         interpolator_ = interpolator ?? new Interpolator();
+         interpolator_ = interpolator ?? New<Interpolator>.Instance();
       }
 
       public InterpolatedDiscountCurve(List<Date> dates,
@@ -118,7 +118,7 @@ namespace QLNet
          times_ = new List<double>();
          dates_ = dates;
          data_ = discounts;
-         interpolator_ = interpolator ?? new Interpolator();
+         interpolator_ = interpolator ?? New<Interpolator>.Instance();
          initialize();
       }
 
@@ -160,7 +160,7 @@ namespace QLNet
          times_ = new List<double>();
          dates_ = dates;
          data_ = discounts;
-         interpolator_ = interpolator ?? new Interpolator();
+         interpolator_ = interpolator ?? New<Interpolator>.Instance();
          initialize();
       }
 

--- a/QLNet/Termstructures/Yield/ForwardCurve.cs
+++ b/QLNet/Termstructures/Yield/ForwardCurve.cs
@@ -76,7 +76,7 @@ namespace QLNet
                                       Interpolator interpolator = default(Interpolator))
          : base(dayCounter, jumps, jumpDates)
       {
-         interpolator_ = interpolator ?? new Interpolator();
+         interpolator_ = interpolator ?? New<Interpolator>.Instance();
       }
 
       public InterpolatedForwardCurve(Date referenceDate,
@@ -86,7 +86,7 @@ namespace QLNet
                                       Interpolator interpolator = default(Interpolator))
          : base(referenceDate, null, dayCounter, jumps, jumpDates)
       {
-         interpolator_ = interpolator ?? new Interpolator();
+         interpolator_ = interpolator ?? New<Interpolator>.Instance();
       }
 
       public InterpolatedForwardCurve(int settlementDays,
@@ -97,7 +97,7 @@ namespace QLNet
                                       Interpolator interpolator = default(Interpolator))
          : base(settlementDays, calendar, dayCounter, jumps, jumpDates)
       {
-         interpolator_ = interpolator ?? new Interpolator();
+         interpolator_ = interpolator ?? New<Interpolator>.Instance();
       }
 
       public InterpolatedForwardCurve(List<Date> dates,
@@ -111,7 +111,7 @@ namespace QLNet
       {
          times_ = new List<double>();
          data_ = forwards;
-         interpolator_ = interpolator ?? new Interpolator();
+         interpolator_ = interpolator ?? New<Interpolator>.Instance();
          dates_ = dates;
          initialize();
       }
@@ -154,7 +154,7 @@ namespace QLNet
          times_ = new List<double>();
          dates_ = dates;
          data_ = forwards;
-         interpolator_ = interpolator ?? new Interpolator();
+         interpolator_ = interpolator ?? New<Interpolator>.Instance();
          initialize();
       }
 

--- a/QLNet/Termstructures/Yield/InterpolatedPiecewiseZeroSpreadedTermStructure.cs
+++ b/QLNet/Termstructures/Yield/InterpolatedPiecewiseZeroSpreadedTermStructure.cs
@@ -40,7 +40,7 @@ namespace QLNet
          compounding_ = compounding;
          frequency_ = frequency;
          dc_ = dc ?? new DayCounter();
-         factory_ = factory ?? new Interpolator();
+         factory_ = factory ?? New<Interpolator>.Instance();
 
          Utils.QL_REQUIRE(!spreads_.empty(), () => "no spreads given");
          Utils.QL_REQUIRE(spreads_.Count == dates_.Count, () => "spread and date vector have different sizes");

--- a/QLNet/Termstructures/Yield/PiecewiseYieldCurve.cs
+++ b/QLNet/Termstructures/Yield/PiecewiseYieldCurve.cs
@@ -174,14 +174,14 @@ namespace QLNet {
       #region Constructors
       public PiecewiseYieldCurve(Date referenceDate, List<RateHelper> instruments, DayCounter dayCounter)
          : this(referenceDate, instruments, dayCounter, new List<Handle<Quote>>(), new List<Date>(), 
-                  1.0e-12, new Interpolator(), new BootStrap()) { }
+                  1.0e-12, New<Interpolator>.Instance(), new BootStrap()) { }
       public PiecewiseYieldCurve(Date referenceDate, List<RateHelper> instruments,
                                  DayCounter dayCounter, List<Handle<Quote>> jumps, List<Date> jumpDates)
-         : this(referenceDate, instruments, dayCounter, jumps, jumpDates, 1.0e-12, new Interpolator(), new BootStrap()) { }
+         : this(referenceDate, instruments, dayCounter, jumps, jumpDates, 1.0e-12, New<Interpolator>.Instance(), new BootStrap()) { }
       public PiecewiseYieldCurve(Date referenceDate, List<RateHelper> instruments,
                                  DayCounter dayCounter, List<Handle<Quote>> jumps,
                                  List<Date> jumpDates, double accuracy)
-         : this(referenceDate, instruments, dayCounter, jumps, jumpDates, accuracy, new Interpolator(), new BootStrap()) { }
+         : this(referenceDate, instruments, dayCounter, jumps, jumpDates, accuracy, New<Interpolator>.Instance(), new BootStrap()) { }
       public PiecewiseYieldCurve(Date referenceDate, List<RateHelper> instruments,
                                  DayCounter dayCounter, List<Handle<Quote>> jumps,
                                  List<Date> jumpDates, double accuracy, Interpolator i)
@@ -196,7 +196,7 @@ namespace QLNet {
          accuracy_ = accuracy;
          interpolator_ = i;
          bootstrap_ = bootstrap;
-         _traits_ = new Traits();
+         _traits_ = New<Traits>.Instance();
 
          bootstrap_.setup(this);
       }
@@ -212,7 +212,7 @@ namespace QLNet {
       public PiecewiseYieldCurve(int settlementDays, Calendar calendar, List<RateHelper> instruments,
                                  DayCounter dayCounter, List<Handle<Quote>> jumps, List<Date> jumpDates, double accuracy)
          : this(settlementDays, calendar, instruments, dayCounter, jumps, jumpDates, accuracy, 
-                  new Interpolator(), new BootStrap()) { }
+                  New<Interpolator>.Instance(), new BootStrap()) { }
       public PiecewiseYieldCurve(int settlementDays, Calendar calendar, List<RateHelper> instruments,
                                  DayCounter dayCounter,  List<Handle<Quote>> jumps, List<Date> jumpDates, double accuracy,
                                  Interpolator i, BootStrap bootstrap)
@@ -221,7 +221,7 @@ namespace QLNet {
          accuracy_ = accuracy;
          interpolator_ = i;
          bootstrap_ = bootstrap;
-         _traits_ = new Traits();
+         _traits_ = New<Traits>.Instance();
 
          bootstrap_.setup(this);
       } 

--- a/QLNet/Termstructures/Yield/ZeroCurve.cs
+++ b/QLNet/Termstructures/Yield/ZeroCurve.cs
@@ -77,7 +77,7 @@ namespace QLNet
                                    Interpolator interpolator = default(Interpolator))
          : base(dayCounter, jumps, jumpDates)
       {
-         interpolator_ = interpolator ?? new Interpolator();
+         interpolator_ = interpolator ?? New<Interpolator>.Instance();
       }
 
       public InterpolatedZeroCurve(Date referenceDate,
@@ -87,7 +87,7 @@ namespace QLNet
                                    Interpolator interpolator = default(Interpolator))
          : base(referenceDate, null, dayCounter, jumps, jumpDates)
       {
-         interpolator_ = interpolator ?? new Interpolator();
+         interpolator_ = interpolator ?? New<Interpolator>.Instance();
       }
 
       public InterpolatedZeroCurve(int settlementDays,
@@ -98,7 +98,7 @@ namespace QLNet
                                    Interpolator interpolator = default(Interpolator))
          : base(settlementDays, calendar, dayCounter, jumps, jumpDates)
       {
-         interpolator_ = interpolator ?? new Interpolator();
+         interpolator_ = interpolator ?? New<Interpolator>.Instance();
       }
 
       public InterpolatedZeroCurve(List<Date> dates,
@@ -115,7 +115,7 @@ namespace QLNet
          times_ = new List<double>();
          dates_ = dates;
          data_ = yields;
-         interpolator_ = interpolator ?? new Interpolator();
+         interpolator_ = interpolator ?? New<Interpolator>.Instance();
          initialize(compounding, frequency);
       }
 

--- a/QLNet/Utils.cs
+++ b/QLNet/Utils.cs
@@ -1,17 +1,17 @@
 /*
  Copyright (C) 2008 Siarhei Novik (snovik@gmail.com)
-  
+
  This file is part of QLNet Project https://github.com/amaggiulli/qlnet
 
  QLNet is free software: you can redistribute it and/or modify it
  under the terms of the QLNet license.  You should have received a
- copy of the license along with this program; if not, license is  
+ copy of the license along with this program; if not, license is
  available online at <http://qlnet.sourceforge.net/License.html>.
-  
+
  QLNet is a based on QuantLib, a free-software/open-source library
  for financial quantitative analysts and developers - http://quantlib.org/
  The QuantLib license is available online at http://quantlib.org/license.shtml.
- 
+
  This program is distributed in the hope that it will be useful, but WITHOUT
  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
  FOR A PARTICULAR PURPOSE.  See the license for more details.
@@ -20,7 +20,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 
-namespace QLNet 
+namespace QLNet
 {
     // here are extensions to IList to accomodate some QL functionality as well as have useful things for .net
     public static partial class Utils {
@@ -73,7 +73,7 @@ namespace QLNet
                 if ((n >>= 1) == 0) return y < 0 ? 1 / retval : retval;
             }
         }
-        
+
        public static void QL_REQUIRE( bool condition, Func<string> message )
        {
           if ( !condition )
@@ -100,7 +100,7 @@ namespace QLNet
         public InitializedList() : base() { }
         public InitializedList(int size) : base(size) {
             for (int i = 0; i < this.Capacity; i++)
-                this.Add(default(T) == null ? new T() : default(T));
+                this.Add(default(T) == null ? New<T>.Instance() : default(T));
         }
         public InitializedList(int size, T value) : base(size) {
             for (int i = 0; i < this.Capacity; i++)
@@ -110,7 +110,7 @@ namespace QLNet
         // erases the contents without changing the size
         public void Erase() {
             for (int i = 0; i < this.Count; i++)
-                this[i] = default(T);       // do we need to use "new T()" instead of default(T) when T is class?
+                this[i] = default(T);       // do we need to use "New<T>.Instance()" instead of default(T) when T is class?
         }
     }
 }


### PR DESCRIPTION
When `T` is a generic class, `new T()` is slow. In fact, it is just syntactic sugar and the actual code that is emitted to IL is `Activator.CreateInstance<T>();`, which uses reflection. A much faster way is to use lambda expression trees. There are many discussions on the web that describe this, e.g. http://stackoverflow.com/questions/6069661/does-system-activator-createinstancet-have-performance-issues-big-enough-to-di

I admit that it doesn't make a big difference in our test suite, but in a scenario where the user will create many thousands of the same object, it will make a difference. I have a test app that demonstrates the impact.
