### PR TITLE
Update FuturesRateHelper Constructor

### DIFF
--- a/QLNet/Termstructures/Yield/Ratehelpers.cs
+++ b/QLNet/Termstructures/Yield/Ratehelpers.cs
@@ -35,6 +35,8 @@ namespace QLNet
                                 Futures.Type type= Futures.Type.IMM)
          : base( price )
       {
+         convAdj_ = convAdj ?? new Handle<Quote>();
+         
          switch (type) 
          {
             case QLNet.Futures.Type.IMM:


### PR DESCRIPTION
A missing initialization of convAdj_ raised an exception when using this constructor. 
A simple check allows to correct this.