### PR TITLE
Changes to support multi-target framework. The main solution now cont…

### DIFF
--- a/QLNet.sln
+++ b/QLNet.sln
@@ -9,12 +9,21 @@ Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
 		Release|Any CPU = Release|Any CPU
+		Release-net40|Any CPU = Release-net40|Any CPU
+		Release-net45|Any CPU = Release-net45|Any CPU
+		Release-net46|Any CPU = Release-net46|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{F6E762BD-DCDF-4CA0-ABAD-CB21C7D03BEC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{F6E762BD-DCDF-4CA0-ABAD-CB21C7D03BEC}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{F6E762BD-DCDF-4CA0-ABAD-CB21C7D03BEC}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{F6E762BD-DCDF-4CA0-ABAD-CB21C7D03BEC}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F6E762BD-DCDF-4CA0-ABAD-CB21C7D03BEC}.Release-net40|Any CPU.ActiveCfg = Release-net40|Any CPU
+		{F6E762BD-DCDF-4CA0-ABAD-CB21C7D03BEC}.Release-net40|Any CPU.Build.0 = Release-net40|Any CPU
+		{F6E762BD-DCDF-4CA0-ABAD-CB21C7D03BEC}.Release-net45|Any CPU.ActiveCfg = Release-net45|Any CPU
+		{F6E762BD-DCDF-4CA0-ABAD-CB21C7D03BEC}.Release-net45|Any CPU.Build.0 = Release-net45|Any CPU
+		{F6E762BD-DCDF-4CA0-ABAD-CB21C7D03BEC}.Release-net46|Any CPU.ActiveCfg = Release-net46|Any CPU
+		{F6E762BD-DCDF-4CA0-ABAD-CB21C7D03BEC}.Release-net46|Any CPU.Build.0 = Release-net46|Any CPU
 		{2EF8B45B-940A-4B77-8776-E8CE0036961E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{2EF8B45B-940A-4B77-8776-E8CE0036961E}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{2EF8B45B-940A-4B77-8776-E8CE0036961E}.Release|Any CPU.ActiveCfg = Release|Any CPU

--- a/QLNet/QLNet.csproj
+++ b/QLNet/QLNet.csproj
@@ -55,11 +55,42 @@
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release-net40|AnyCPU'">
+    <OutputPath>bin\Release-net40\</OutputPath>
+    <DefineConstants>TRACE;QL_NEGATIVE_RATES,QL_DOTNET_FRAMEWORK</DefineConstants>
+    <Optimize>true</Optimize>
+    <DebugType>pdbonly</DebugType>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
+    <Prefer32Bit>false</Prefer32Bit>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release-net45|AnyCPU'">
+    <OutputPath>bin\Release-net45\</OutputPath>
+    <DefineConstants>TRACE;QL_NEGATIVE_RATES,QL_DOTNET_FRAMEWORK</DefineConstants>
+    <Optimize>true</Optimize>
+    <DebugType>pdbonly</DebugType>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
+    <Prefer32Bit>false</Prefer32Bit>
+  </PropertyGroup>    
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release-net46|AnyCPU'">
+    <OutputPath>bin\Release-net46\</OutputPath>
+    <DefineConstants>TRACE;QL_NEGATIVE_RATES,QL_DOTNET_FRAMEWORK</DefineConstants>
+    <Optimize>true</Optimize>
+    <DebugType>pdbonly</DebugType>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
+    <Prefer32Bit>false</Prefer32Bit>
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
-    <Reference Include="System.Core">
-      <RequiredTargetFramework>3.5</RequiredTargetFramework>
-    </Reference>
+    <Reference Include="System.Core"/>
     <Reference Include="System.Data" />
     <Reference Include="System.Numerics" />
     <Reference Include="System.Xml" />
@@ -671,23 +702,6 @@
     <Compile Include="Time\Schedule.cs" />
     <Compile Include="Types.cs" />
     <Compile Include="Utils.cs" />
-  </ItemGroup>
-  <ItemGroup>
-    <BootstrapperPackage Include="Microsoft.Net.Client.3.5">
-      <Visible>False</Visible>
-      <ProductName>.NET Framework 3.5 SP1 Client Profile</ProductName>
-      <Install>false</Install>
-    </BootstrapperPackage>
-    <BootstrapperPackage Include="Microsoft.Net.Framework.3.5.SP1">
-      <Visible>False</Visible>
-      <ProductName>.NET Framework 3.5 SP1</ProductName>
-      <Install>true</Install>
-    </BootstrapperPackage>
-    <BootstrapperPackage Include="Microsoft.Windows.Installer.3.1">
-      <Visible>False</Visible>
-      <ProductName>Windows Installer 3.1</ProductName>
-      <Install>true</Install>
-    </BootstrapperPackage>
   </ItemGroup>
   <ItemGroup>
     <None Include=".editorconfig" />

--- a/QLNet/QLNet.nuspec
+++ b/QLNet/QLNet.nuspec
@@ -14,4 +14,10 @@
     <copyright>Copyright (c) 2008-2014 Andrea Maggiulli (a.maggiulli@gmail.com)</copyright>
     <tags>QLNet QuantLib quantitative finance financial</tags>
   </metadata>
+  <files>
+	<file src="bin\Release-net40\QLNet.dll" target="lib\net40\QLNet.dll" />
+	<file src="bin\Release-net45\QLNet.dll" target="lib\net45\QLNet.dll" />
+	<file src="bin\Release-net46\QLNet.dll" target="lib\net46\QLNet.dll" />
+	<file src="bin\Release\netstandard1.1\QLNet.dll" target="lib\netstandard1.1\QLNet.dll" />	
+  </files>
 </package>


### PR DESCRIPTION
…ains three extra build configs that support 4.0, 4.5 and 4.6

on App Veyor each of these will need to be built in addition to this line:

 msbuild "C:\projects\qlnet\QLNet.sln" /verbosity:minimal /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"

should have also

  msbuild "C:\projects\qlnet\QLNet.sln" /Configuration="Release-net40"  /verbosity:minimal /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
  msbuild "C:\projects\qlnet\QLNet.sln" /Configuration="Release-net45" /verbosity:minimal /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
  msbuild "C:\projects\qlnet\QLNet.sln" /Configuration="Release-net46" /verbosity:minimal /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"

as well as that the Net Core soln needs to be built

   msbuild "C:\projects\qlnet\QLNet_Core.sln" /verbosity:minimal /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"

then the comand to pack to the nuget package should be changed to:

nuget.exe pack QLNet.nuspec