### PR TITLE
Add negation on needsForecast else case

### DIFF
--- a/src/QLNet/Indexes/InflationIndex.cs
+++ b/src/QLNet/Indexes/InflationIndex.cs
@@ -252,7 +252,7 @@ namespace QLNet
             // we're not sure, but the fixing might be there so we
             // check.  Todo: check which fixings are not possible, to
             // avoid using fixings in the future
-            return IndexManager.instance().getHistory( name() ).value().ContainsKey( latestNeededDate );
+            return !( IndexManager.instance().getHistory( name() ).value().ContainsKey( latestNeededDate ) );
          }
       }
       private double forecastFixing( Date fixingDate )


### PR DESCRIPTION
Quantlib source gives:
Real f = timeSeries()[latestNeededDate];
return (f == Null<Real>());

which will return "true" when the latestNeededDate isn't found