### PR TITLE
Add a new constructor to manage the Interpolator

### DIFF
--- a/src/QLNet/Termstructures/Inflation/InterpolatedZeroInflationCurve.cs
+++ b/src/QLNet/Termstructures/Inflation/InterpolatedZeroInflationCurve.cs
@@ -25,6 +25,11 @@ namespace QLNet
        where Interpolator : class, IInterpolationFactory, new()
    {
       public InterpolatedZeroInflationCurve(Date referenceDate, Calendar calendar, DayCounter dayCounter, Period lag,
+                                              Frequency frequency, bool indexIsInterpolated, Handle<YieldTermStructure> yTS,
+                                              List<Date> dates, List<double> rates)
+           : this(referenceDate, calendar, dayCounter, lag, frequency, indexIsInterpolated, yTS, dates, rates, FastActivator<Interpolator>.Create()) { }
+
+      public InterpolatedZeroInflationCurve(Date referenceDate, Calendar calendar, DayCounter dayCounter, Period lag,
                                             Frequency frequency, bool indexIsInterpolated, Handle<YieldTermStructure> yTS,
                                             List<Date> dates, List<double> rates,
                                             Interpolator interpolator = default(Interpolator))
@@ -92,10 +97,16 @@ namespace QLNet
       public Date maxDate_ { get; set; }
       public override Date maxDate()
       {
-         if ( maxDate_ != null )
-            return maxDate_;
-
-         return dates_.Last();
+         Date d;
+         if (indexIsInterpolated())
+         {
+            d = dates_.Last();
+         }
+         else
+         {
+            d = Utils.inflationPeriod(dates_.Last(), frequency()).Value;
+         }
+         return d;
       }
 
       public List<double> data_ { get; set; }


### PR DESCRIPTION
This new interpolator will help to manage dynamically the Interpolator (and it's already done in InterpolatedZeroCurve).

Example of application

```
IInterpolationFactory InterpMethod = ConvertStringToInterpolation(Interpolation);
var type = typeof(InterpolatedZeroInflationCurve<>).MakeGenericType(InterpMethod.GetType());
InterpolatedZeroCurve InflationZeroCurve = Activator.CreateInstance(type, baseRateDate, cal, curve_dc, lag, Frequency.Monthly, false, new Handle<YieldTermStructure>(ois_curve), dates, zc) as ZeroInflationTermStructure;
```