### PR TITLE
Bugfix when cap/floor equals zero

### DIFF
--- a/src/QLNet/Cashflows/Cashflowvectors.cs
+++ b/src/QLNet/Cashflows/Cashflowvectors.cs
@@ -26,9 +26,9 @@ namespace QLNet
 {
    public static partial class Utils
    {
-      public static double? toNullable(double val)
+      public static double? toNullable(double? val)
       {
-         if (val.IsEqual(double.MinValue))
+         if (val.IsEqual(double.MinValue) || val == null)
             return null;
          return val;
       }
@@ -45,8 +45,8 @@ namespace QLNet
          List<int> fixingDays,
          List<double> gearings,
          List<double> spreads,
-         List<double> caps,
-         List<double> floors,
+         List<double?> caps,
+         List<double?> floors,
          bool isInArrears,
          bool isZero)
          where InterestRateIndexType : InterestRateIndex, new()
@@ -271,8 +271,8 @@ namespace QLNet
                                                    List<double> gearings_,
                                                    List<double> spreads_,
                                                    DayCounter paymentDayCounter_,
-                                                   List<double> caps_,
-                                                   List<double> floors_,
+                                                   List<double?> caps_,
+                                                   List<double?> floors_,
                                                    Calendar paymentCalendar_,
                                                    List<int> fixingDays_,
                                                    Period observationLag_)

--- a/src/QLNet/Cashflows/RateLegBase.cs
+++ b/src/QLNet/Cashflows/RateLegBase.cs
@@ -63,8 +63,8 @@ namespace QLNet
 
       protected List<double> gearings_;
       protected List<double> spreads_;
-      protected List<double> caps_ = new List<double>();
-      protected List<double> floors_ = new List<double>();
+      protected List<double?> caps_ = new List<double?>();
+      protected List<double?> floors_ = new List<double?>();
       protected bool inArrears_;
       protected bool zeroPayments_;
 
@@ -111,25 +111,25 @@ namespace QLNet
          return this;
       }
 
-      public FloatingLegBase withCaps(double cap)
+      public FloatingLegBase withCaps(double? cap)
       {
-         caps_ = new List<double>() {cap};
+         caps_ = new List<double?>() {cap};
          return this;
       }
 
-      public FloatingLegBase withCaps(List<double> caps)
+      public FloatingLegBase withCaps(List<double?> caps)
       {
          caps_ = caps;
          return this;
       }
 
-      public FloatingLegBase withFloors(double floor)
+      public FloatingLegBase withFloors(double? floor)
       {
-         floors_ = new List<double>() {floor};
+         floors_ = new List<double?>() {floor};
          return this;
       }
 
-      public FloatingLegBase withFloors(List<double> floors)
+      public FloatingLegBase withFloors(List<double?> floors)
       {
          floors_ = floors;
          return this;
@@ -207,12 +207,12 @@ namespace QLNet
 
       public yoyInflationLegBase withCaps(double cap)
       {
-         caps_ = new List<double>();
+         caps_ = new List<double?>();
          caps_.Add(cap);
          return this;
       }
 
-      public yoyInflationLegBase withCaps(List<double> caps)
+      public yoyInflationLegBase withCaps(List<double?> caps)
       {
          caps_ = caps;
          return this;
@@ -220,12 +220,12 @@ namespace QLNet
 
       public yoyInflationLegBase withFloors(double floor)
       {
-         floors_ = new List<double>();
+         floors_ = new List<double?>();
          floors_.Add(floor);
          return this;
       }
 
-      public yoyInflationLegBase withFloors(List<double> floors)
+      public yoyInflationLegBase withFloors(List<double?> floors)
       {
          floors_ = floors;
          return this;
@@ -237,7 +237,7 @@ namespace QLNet
       protected List<int> fixingDays_;
       protected List<double> gearings_;
       protected List<double> spreads_;
-      protected List<double> caps_, floors_;
+      protected List<double?> caps_, floors_;
 
     }
 
@@ -306,11 +306,11 @@ namespace QLNet
 
       public CPILegBase withCaps(double cap)
       {
-         caps_ = new List<double>() { cap };
+         caps_ = new List<double?>() { cap };
          return this;
       }
 
-      public CPILegBase withCaps(List<double> cap)
+      public CPILegBase withCaps(List<double?> cap)
       {
          caps_ = cap;
          return this;
@@ -318,11 +318,11 @@ namespace QLNet
 
       public CPILegBase withFloors(double floors)
       {
-         floors_ = new List<double>() { floors };
+         floors_ = new List<double?>() { floors };
          return this;
       }
 
-      public CPILegBase withFloors(List<double> floors)
+      public CPILegBase withFloors(List<double?> floors)
       {
          floors_ = floors;
          return this;
@@ -345,7 +345,7 @@ namespace QLNet
       protected InterpolationType observationInterpolation_;
       protected bool subtractInflationNominal_;
       protected List<double> spreads_;
-      protected List<double> caps_, floors_;
+      protected List<double?> caps_, floors_;
       protected Calendar paymentCalendar_;
     
       protected Period exCouponPeriod_;

--- a/src/QLNet/Instruments/Bonds/AmortizingCmsRateBond.cs
+++ b/src/QLNet/Instruments/Bonds/AmortizingCmsRateBond.cs
@@ -32,8 +32,8 @@ namespace QLNet
                                int fixingDays = 0,
                                List<double> gearings = null,
                                List<double> spreads = null,
-                               List<double> caps = null,
-                               List<double> floors = null,
+                               List<double?> caps = null,
+                               List<double?> floors = null,
                                bool inArrears = false,
                                Date issueDate = null)
          :base(settlementDays, schedule.calendar(), issueDate)
@@ -41,8 +41,8 @@ namespace QLNet
          // Optional value check
          if ( gearings == null ) gearings = new List<double>(){1.0};
          if ( spreads == null ) spreads = new List<double>(){0};
-         if (caps == null) caps = new List<double>();
-         if (floors == null) floors = new List<double>();
+         if (caps == null) caps = new List<double?>();
+         if (floors == null) floors = new List<double?>();
 
          maturityDate_ = schedule.endDate();
 

--- a/src/QLNet/Instruments/Bonds/AmortizingFloatingRateBond.cs
+++ b/src/QLNet/Instruments/Bonds/AmortizingFloatingRateBond.cs
@@ -32,8 +32,8 @@ namespace QLNet
                                         int fixingDays = 0,
                                         List<double> gearings = null,
                                         List<double> spreads = null,
-                                        List<double> caps = null,
-                                        List<double> floors = null,
+                                        List<double?> caps = null,
+                                        List<double?> floors = null,
                                         bool inArrears = false,
                                         Date issueDate = null)
          :base(settlementDays, schedule.calendar(), issueDate)
@@ -45,10 +45,10 @@ namespace QLNet
             spreads = new List<double>() { 1, 0.0 };
 
          if (caps == null)
-            caps = new List<double>() ;
+            caps = new List<double?>() ;
 
          if (floors == null)
-            floors = new List<double>();
+            floors = new List<double?>();
 
          maturityDate_ = schedule.endDate();
 

--- a/src/QLNet/Instruments/Bonds/BTP.cs
+++ b/src/QLNet/Instruments/Bonds/BTP.cs
@@ -43,8 +43,8 @@ namespace QLNet
                        new Euribor6M().fixingDays(),
                        new List<double>{1.0}, // gearing
                        new List<double>{spread},
-                       new List<double>(), // caps
-                       new List<double>(), // floors
+                       new List<double?>(), // caps
+                       new List<double?>(), // floors
                        false, // in arrears
                        100.0, // redemption
                        issueDate) {}

--- a/src/QLNet/Instruments/Bonds/CmsRateBond.cs
+++ b/src/QLNet/Instruments/Bonds/CmsRateBond.cs
@@ -31,8 +31,8 @@ namespace QLNet
                             int fixingDays = 0,
                             List<double> gearings = null,
                             List<double> spreads = null,
-                            List<double> caps = null,
-                            List<double> floors = null,
+                            List<double?> caps = null,
+                            List<double?> floors = null,
                             bool inArrears = false,
                             double redemption = 100.0,
                             Date issueDate = null)
@@ -41,8 +41,8 @@ namespace QLNet
              // Optional value check
              if ( gearings == null ) gearings = new List<double>(){1};
              if ( spreads == null ) spreads = new List<double>(){0};
-             if (caps == null) caps = new List<double>();
-             if (floors == null) floors = new List<double>();
+             if (caps == null) caps = new List<double?>();
+             if (floors == null) floors = new List<double?>();
 
              maturityDate_ = schedule.endDate();
              cashflows_ = new CmsLeg(schedule, index)

--- a/src/QLNet/Instruments/Bonds/FloatingRateBond.cs
+++ b/src/QLNet/Instruments/Bonds/FloatingRateBond.cs
@@ -26,16 +26,16 @@ namespace QLNet {
         public FloatingRateBond(int settlementDays, double faceAmount, Schedule schedule, IborIndex index, 
                                 DayCounter paymentDayCounter)
             : this(settlementDays, faceAmount, schedule, index, paymentDayCounter, BusinessDayConvention.Following,
-                   0, new List<double>() { 1 }, new List<double>() { 0 }, new List<double>(), new List<double>(),
+                   0, new List<double>() { 1 }, new List<double>() { 0 }, new List<double?>(), new List<double?>(),
                    false, 100, null) { }
         public FloatingRateBond(int settlementDays, double faceAmount, Schedule schedule, IborIndex index,
                                 DayCounter paymentDayCounter, BusinessDayConvention paymentConvention, int fixingDays, 
                                 List<double> gearings, List<double> spreads)
             : this(settlementDays, faceAmount, schedule, index, paymentDayCounter, BusinessDayConvention.Following,
-                   fixingDays, gearings, spreads, new List<double>(), new List<double>(), false, 100, null) { }
+                   fixingDays, gearings, spreads, new List<double?>(), new List<double?>(), false, 100, null) { }
         public FloatingRateBond(int settlementDays, double faceAmount, Schedule schedule, IborIndex index, DayCounter paymentDayCounter,
                                 BusinessDayConvention paymentConvention, int fixingDays, List<double> gearings, List<double> spreads,
-                                List<double> caps, List<double> floors, bool inArrears, double redemption, Date issueDate)
+                                List<double?> caps, List<double?> floors, bool inArrears, double redemption, Date issueDate)
             : base(settlementDays, schedule.calendar(), issueDate) {
             maturityDate_ = schedule.endDate();
             cashflows_ = new IborLeg(schedule, index)
@@ -75,8 +75,8 @@ namespace QLNet {
         public FloatingRateBond(int settlementDays, double faceAmount, Date startDate, Date maturityDate, Frequency couponFrequency,
                                 Calendar calendar, IborIndex index, DayCounter accrualDayCounter,
                                 BusinessDayConvention accrualConvention, BusinessDayConvention paymentConvention,
-                                int fixingDays, List<double> gearings, List<double> spreads, List<double> caps,
-                                List<double> floors, bool inArrears, double redemption, Date issueDate,
+                                int fixingDays, List<double> gearings, List<double> spreads, List<double?> caps,
+                                List<double?> floors, bool inArrears, double redemption, Date issueDate,
                                 Date stubDate, DateGeneration.Rule rule, bool endOfMonth)
             : base(settlementDays, calendar, issueDate) {
 

--- a/src/QLNet/Instruments/MakeCms.cs
+++ b/src/QLNet/Instruments/MakeCms.cs
@@ -38,8 +38,8 @@ namespace QLNet
          forwardStart_ = forwardStart ?? new Period(0,TimeUnit.Days);
          cmsSpread_ = 0.0; 
          cmsGearing_ = 1.0;
-         cmsCap_ = 0; 
-         cmsFloor_ = 0;
+         cmsCap_ = null; 
+         cmsFloor_ = null;
          effectiveDate_ = null;
          cmsCalendar_ = swapIndex.fixingCalendar();
          floatCalendar_ = iborIndex.fixingCalendar();
@@ -76,8 +76,8 @@ namespace QLNet
          forwardStart_ = forwardStart ?? new Period(0,TimeUnit.Days);
          cmsSpread_ = 0.0; 
          cmsGearing_ = 1.0;
-         cmsCap_ = 0; 
-         cmsFloor_ = 0;
+         cmsCap_ = null; 
+         cmsFloor_ = null;
          effectiveDate_ = null;
          cmsCalendar_ = swapIndex.fixingCalendar();
          floatCalendar_ = iborIndex_.fixingCalendar();
@@ -335,7 +335,7 @@ namespace QLNet
 
       private double cmsSpread_;
       private double cmsGearing_;
-      private double cmsCap_, cmsFloor_;
+      private double? cmsCap_, cmsFloor_;
 
       private Date effectiveDate_;
       private Calendar cmsCalendar_, floatCalendar_;

--- a/src/QLNet/Utils.cs
+++ b/src/QLNet/Utils.cs
@@ -35,8 +35,24 @@ namespace QLNet
         }
 
         // this is a version of element retrieval with some logic for default values
-        public static T Get<T>(this List<T> v, int i) { return Get(v, i, default(T)); }
-        public static T Get<T>(this List<T> v, int i, T defval) {
+        public static T Get<T>(this List<T> v, int i)
+        {
+            return Get(v, i, default(T));
+        }
+        public static T Get<T>(this List<T> v, int i, T defval)
+        {
+            if (v == null || v.Count == 0) return defval;
+            else if (i >= v.Count) return v.Last();
+            else return v[i];
+        }
+        public static Nullable<T> Get<T>(this List<Nullable<T>> v, int i) 
+            where T : struct 
+        { 
+            return Get(v, i, null); 
+        }
+        public static Nullable<T> Get<T>(this List<Nullable<T>> v, int i, Nullable<T> defval)
+             where T : struct 
+        {
             if (v == null || v.Count == 0) return defval;
             else if (i >= v.Count) return v.Last();
             else return v[i];
@@ -45,17 +61,17 @@ namespace QLNet
 
 
     public static partial class Utils {
-        public static double effectiveFixedRate(List<double> spreads, List<double> caps, List<double> floors, int i) {
+        public static double effectiveFixedRate(List<double> spreads, List<double?> caps, List<double?> floors, int i) {
             double result = Get(spreads, i);
-            double floor = Get(floors, i);
-            double cap = Get(caps, i);
-            if (floor.IsNotEqual(default(double))) result = Math.Max(floor, result);
-            if (cap.IsNotEqual(default(double))) result = Math.Min(cap, result);
+            double? floor = Get(floors, i);
+            double? cap = Get(caps, i);
+            if (floor != null) result = Math.Max(Convert.ToDouble(floor), result);
+            if (cap != null) result = Math.Min(Convert.ToDouble(cap), result);
             return result;
         }
 
-        public static bool noOption(List<double> caps, List<double> floors, int i) {
-            return Get(caps, i).IsEqual(default(double)) && Get(floors, i).IsEqual(default(double));
+        public static bool noOption(List<double?> caps, List<double?> floors, int i) {
+            return Get(caps, i) == null && Get(floors, i) == null;
         }
 
         public static void swap(ref double a1, ref double a2) { swap<double>(ref a1, ref a2); }

--- a/tests/QLNet.Tests/T_AssetSwap.cs
+++ b/tests/QLNet.Tests/T_AssetSwap.cs
@@ -531,8 +531,8 @@ namespace TestSuite
                                                    BusinessDayConvention.Following, fixingDays,
                                                    new List<double>(){1},
                                                    new List<double>(){0.0056},
-                                                   new List<double>(),
-                                                   new List<double>(),
+                                                   new List<double?>(),
+                                                   new List<double?>(),
                                                    inArrears,
                                                    100.0, new Date(29,Month.September,2003));
 
@@ -569,8 +569,8 @@ namespace TestSuite
                                                     BusinessDayConvention.ModifiedFollowing, fixingDays,
                                                     new List<double>(){1},
                                                     new List<double>(){0.0025},
-                                                    new List<double>(),
-                                                    new List<double>(),
+                                                    new List<double?>(),
+                                                    new List<double?>(),
                                                     inArrears,
                                                     100.0, new Date(24,Month.September,2004));
 
@@ -620,8 +620,8 @@ namespace TestSuite
                                              BusinessDayConvention.Following, fixingDays,
                                              new List<double>(){1.0},
                                              new List<double>(){0.0},
-                                             new List<double>(){0.055},
-                                             new List<double>(){0.025},
+                                             new List<double?>(){0.055},
+                                             new List<double?>(){0.025},
                                              inArrears,
                                              100.0, new Date(22,Month.August,2005));
 
@@ -656,7 +656,7 @@ namespace TestSuite
                         vars.swapIndex, new Thirty360(),
                         BusinessDayConvention.Following, fixingDays,
                         new List<double>(){0.84}, new List<double>(){0.0},
-                        new List<double>(), new List<double>(),
+                        new List<double?>(), new List<double?>(),
                         inArrears,
                         100.0, new Date(06,Month.May,2005));
 
@@ -854,7 +854,7 @@ namespace TestSuite
                               vars.iborIndex, new Actual360(),
                               BusinessDayConvention.Following, fixingDays,
                               new List<double>{1}, new List<double>{0.0056},
-                              new List<double>(), new List<double>(),
+                              new List<double?>(), new List<double?>(),
                               inArrears,
                               100.0, new Date(29,Month.September,2003));
 
@@ -905,7 +905,7 @@ namespace TestSuite
                               vars.iborIndex, new Actual360(),
                               BusinessDayConvention.ModifiedFollowing, fixingDays,
                               new List<double>{1}, new List<double>{0.0025},
-                              new List<double>(), new List<double>(),
+                              new List<double?>(), new List<double?>(),
                               inArrears,
                               100.0, new Date(24,Month.September,2004));
 
@@ -955,7 +955,7 @@ namespace TestSuite
                         vars.swapIndex, new Thirty360(),
                         BusinessDayConvention.Following, fixingDays,
                         new List<double>{1.0}, new List<double>{0.0},
-                        new List<double>{0.055}, new List<double>{0.025},
+                        new List<double?>{0.055}, new List<double?>{0.025},
                         inArrears,
                         100.0, new Date(22,Month.August,2005));
 
@@ -1004,7 +1004,7 @@ namespace TestSuite
                         vars.swapIndex, new Thirty360(),
                         BusinessDayConvention.Following, fixingDays,
                         new List<double>{0.84}, new List<double>{0.0},
-                        new List<double>(), new List<double>(),
+                        new List<double?>(), new List<double?>(),
                         inArrears,
                         100.0, new Date(06,Month.May,2005));
 
@@ -1216,7 +1216,7 @@ namespace TestSuite
                               vars.iborIndex, new Actual360(),
                               BusinessDayConvention.Following, fixingDays,
                               new List<double>{1}, new List<double>{0.0056},
-                              new List<double>(), new List<double>(),
+                              new List<double?>(), new List<double?>(),
                               inArrears,
                               100.0, new Date(29,Month.September,2003));
 
@@ -1252,7 +1252,7 @@ namespace TestSuite
                               vars.iborIndex, new Actual360(),
                               BusinessDayConvention.ModifiedFollowing, fixingDays,
                               new List<double>{1}, new List<double>{0.0025},
-                              new List<double>(), new List<double>(),
+                              new List<double?>(), new List<double?>(),
                               inArrears,
                               100.0, new Date(24,Month.September,2004));
 
@@ -1287,7 +1287,7 @@ namespace TestSuite
                         vars.swapIndex, new Thirty360(),
                         BusinessDayConvention.Following, fixingDays,
                         new List<double>{1.0}, new List<double>{0.0},
-                        new List<double>{0.055}, new List<double>{0.025},
+                        new List<double?>{0.055}, new List<double?>{0.025},
                         inArrears,
                         100.0, new Date(22,Month.August,2005));
 
@@ -1322,7 +1322,7 @@ namespace TestSuite
                         vars.swapIndex, new Thirty360(),
                         BusinessDayConvention.Following, fixingDays,
                         new List<double>{0.84}, new List<double>{0.0},
-                        new List<double>(), new List<double>(),
+                        new List<double?>(), new List<double?>(),
                         inArrears,
                         100.0, new Date(06,Month.May,2005));
 
@@ -2643,7 +2643,7 @@ namespace TestSuite
                                  BusinessDayConvention.Following, fixingDays,
                                  new List<double>{1},
                                  new List<double>{0.0056},
-                                 new List<double>(), new List<double>(),
+                                 new List<double?>(), new List<double?>(),
                                  inArrears,
                                  100.0, new Date(29,Month.September,2003));
          floatingSpecializedBond1.setPricingEngine(bondEngine);
@@ -2714,7 +2714,7 @@ namespace TestSuite
                               BusinessDayConvention.ModifiedFollowing, fixingDays,
                               new List<double>{1},
                               new List<double>{0.0025},
-                              new List<double>(), new List<double>(),
+                              new List<double?>(), new List<double?>(),
                               inArrears,
                               100.0, new Date(24,Month.September,2004));
          floatingSpecializedBond2.setPricingEngine(bondEngine);
@@ -2785,7 +2785,7 @@ namespace TestSuite
                      vars.swapIndex, new Thirty360(),
                      BusinessDayConvention.Following, fixingDays,
                      new List<double>{1.0}, new List<double>{0.0},
-                     new List<double>{0.055}, new List<double>{0.025},
+                     new List<double?>{0.055}, new List<double?>{0.025},
                      inArrears,
                      100.0, new Date(22,Month.August,2005));
          cmsSpecializedBond1.setPricingEngine(bondEngine);
@@ -2846,7 +2846,7 @@ namespace TestSuite
                      vars.swapIndex, new Thirty360(),
                      BusinessDayConvention.Following, fixingDays,
                      new List<double>{0.84}, new List<double>{0.0},
-                     new List<double>(), new List<double>(),
+                     new List<double?>(), new List<double?>(),
                      inArrears, 100.0, new Date(06,Month.May,2005));
          cmsSpecializedBond2.setPricingEngine(bondEngine);
 
@@ -3212,7 +3212,7 @@ namespace TestSuite
                                  BusinessDayConvention.Following, fixingDays,
                                  new List<double>{1},
                                  new List<double>{0.0056},
-                                 new List<double>(), new List<double>(),
+                                 new List<double?>(), new List<double?>(),
                                  inArrears,
                                  100.0, new Date(29,Month.September,2003));
          floatingSpecializedBond1.setPricingEngine(bondEngine);
@@ -3314,7 +3314,7 @@ namespace TestSuite
                               BusinessDayConvention.ModifiedFollowing, fixingDays,
                               new List<double>{1},
                               new List<double>{0.0025},
-                              new List<double>(), new List<double>(),
+                              new List<double?>(), new List<double?>(),
                               inArrears,
                               100.0, new Date(24,Month.September,2004));
          floatingSpecializedBond2.setPricingEngine(bondEngine);
@@ -3416,7 +3416,7 @@ namespace TestSuite
                      vars.swapIndex, new Thirty360(),
                      BusinessDayConvention.Following, fixingDays,
                      new List<double>{1.0}, new List<double>{0.0},
-                     new List<double>{0.055}, new List<double>{0.025},
+                     new List<double?>{0.055}, new List<double?>{0.025},
                      inArrears,
                      100.0, new Date(22,Month.August,2005));
          cmsSpecializedBond1.setPricingEngine(bondEngine);
@@ -3511,7 +3511,7 @@ namespace TestSuite
                      vars.swapIndex, new Thirty360(),
                      BusinessDayConvention.Following, fixingDays,
                      new List<double>{0.84}, new List<double>{0.0},
-                     new List<double>(), new List<double>(),
+                     new List<double?>(), new List<double?>(),
                      inArrears,
                      100.0, new Date(06,Month.May,2005));
          cmsSpecializedBond2.setPricingEngine(bondEngine);

--- a/tests/QLNet.Tests/T_Bonds.cs
+++ b/tests/QLNet.Tests/T_Bonds.cs
@@ -648,7 +648,7 @@ namespace TestSuite
                                 index, new ActualActual(ActualActual.Convention.ISMA),
                                 BusinessDayConvention.ModifiedFollowing, fixingDays,
                                 new List<double>(), new List<double>(),
-                                new List<double>(), new List<double>(),
+                                new List<double?>(), new List<double?>(),
                                 false,
                                 100.0, new Date(30, Month.November, 2004));
 
@@ -678,7 +678,7 @@ namespace TestSuite
                                 index, new ActualActual(ActualActual.Convention.ISMA),
                                 BusinessDayConvention.ModifiedFollowing, fixingDays,
                                 new List<double>(), new List<double>(),
-                                new List<double>(), new List<double>(),
+                                new List<double?>(), new List<double?>(),
                                 false,
                                 100.0, new Date(30, Month.November, 2004));
 
@@ -713,7 +713,7 @@ namespace TestSuite
                                 index, new ActualActual(ActualActual.Convention.ISMA),
                                 BusinessDayConvention.ModifiedFollowing, fixingDays,
                                 new List<double>(), spreads,
-                                new List<double>(), new List<double>(),
+                                new List<double?>(), new List<double?>(),
                                 false,
                                 100.0, new Date(30, Month.November, 2004));
 

--- a/tests/QLNet.Tests/T_CapFlooredCoupon.cs
+++ b/tests/QLNet.Tests/T_CapFlooredCoupon.cs
@@ -99,7 +99,7 @@ namespace TestSuite
                .withPaymentAdjustment(convention);
          }
 
-         public List<CashFlow> makeCapFlooredLeg( Date sDate, int len, List<double> caps, List<double> floors,
+         public List<CashFlow> makeCapFlooredLeg( Date sDate, int len, List<double?> caps, List<double?> floors,
             double volatility,double gearing = 1.0,double spread = 0.0) 
          {
             Date endDate = calendar.advance( sDate, len, TimeUnit.Years, convention );
@@ -172,8 +172,8 @@ namespace TestSuite
             (depending on variance: option expiry and volatility)
          */
 
-         List<double> caps = new InitializedList<double>(vars.length,100.0);
-         List<double> floors = new InitializedList<double>(vars.length,0.0);
+         List<double?> caps = new InitializedList<double?>(vars.length,100.0);
+         List<double?> floors = new InitializedList<double?>(vars.length,0.0);
          double tolerance = 1e-10;
 
          // fixed leg with zero rate
@@ -218,10 +218,10 @@ namespace TestSuite
          double error;
          double floorstrike = 0.05;
          double capstrike = 0.10;
-         List<double> caps = new InitializedList<double>(vars.length,capstrike);
-         List<double> caps0 = new List<double>();
-         List<double> floors = new InitializedList<double>(vars.length,floorstrike);
-         List<double> floors0 = new List<double>();
+         List<double?> caps = new InitializedList<double?>(vars.length,capstrike);
+         List<double?> caps0 = new List<double?>();
+         List<double?> floors = new InitializedList<double?>(vars.length,floorstrike);
+         List<double?> floors0 = new List<double?>();
          double gearing_p = 0.5;
          double spread_p =  0.002;
          double gearing_n = -1.5;

--- a/tests/QLNet.Tests/T_InflationCapFlooredCouponTest.cs
+++ b/tests/QLNet.Tests/T_InflationCapFlooredCouponTest.cs
@@ -200,8 +200,8 @@ namespace TestSuite
       
          public List<CashFlow> makeYoYCapFlooredLeg(int which, Date startDate,
                               int length,
-                              List<double> caps,
-                              List<double> floors,
+                              List<double?> caps,
+                              List<double?> floors,
                               double volatility,
                               double gearing = 1.0,
                               double spread = 0.0) 
@@ -362,10 +362,10 @@ namespace TestSuite
          double error;
          double floorstrike = 0.05;
          double capstrike = 0.10;
-         List<double> caps = new InitializedList<double>(vars.length,capstrike);
-         List<double> caps0 = new List<double>();
-         List<double> floors = new InitializedList<double>(vars.length,floorstrike);
-         List<double> floors0 = new List<double>();
+         List<double?> caps = new InitializedList<double?>(vars.length,capstrike);
+         List<double?> caps0 = new List<double?>();
+         List<double?> floors = new InitializedList<double?>(vars.length,floorstrike);
+         List<double?> floors0 = new List<double?>();
          double gearing_p = 0.5;
          double spread_p = 0.002;
          double gearing_n = -1.5;
@@ -721,16 +721,16 @@ namespace TestSuite
 
                         List<CashFlow> leg2 = vars.makeYoYCapFlooredLeg(whichPricer, from,
                                                             lengths[i],
-                                                            new InitializedList<double>(lengths[i],strikes[j]),//cap
-                                                            new List<double>(),//floor
+                                                            new InitializedList<double?>(lengths[i],strikes[j]),//cap
+                                                            new List<double?>(),//floor
                                                             vols[k],
                                                             1.0,   // gearing
                                                             0.0);// spread
 
                         List<CashFlow> leg3 = vars.makeYoYCapFlooredLeg(whichPricer, from,
                                                             lengths[i],
-                                                            new List<double>(),// cap
-                                                            new InitializedList<double>(lengths[i],strikes[j]),//floor
+                                                            new List<double?>(),// cap
+                                                            new InitializedList<double?>(lengths[i],strikes[j]),//floor
                                                             vols[k],
                                                             1.0,   // gearing
                                                             0.0);// spread


### PR DESCRIPTION
I encountred a bug when the Cap or the Floor on coupons were set to 0.0 : it was considered as coupon without cap or floor.