### PR TITLE
Fix filename after rename

### DIFF
--- a/src/QLNet.Old/QLNet.Old.csproj
+++ b/src/QLNet.Old/QLNet.Old.csproj
@@ -551,8 +551,8 @@
     <Compile Include="..\QLNet\legacy\libormarketmodels\lfmcovarparam.cs">
       <Link>legacy\libormarketmodels\lfmcovarparam.cs</Link>
     </Compile>
-    <Compile Include="..\QLNet\legacy\libormarketmodels\lfmcovarproxy.cs">
-      <Link>legacy\libormarketmodels\lfmcovarproxy.cs</Link>
+    <Compile Include="..\QLNet\legacy\libormarketmodels\LfmCovarianceProxy.cs">
+      <Link>legacy\libormarketmodels\LfmCovarianceProxy.cs</Link>
     </Compile>
     <Compile Include="..\QLNet\legacy\libormarketmodels\lfmhullwhiteparam.cs">
       <Link>legacy\libormarketmodels\lfmhullwhiteparam.cs</Link>


### PR DESCRIPTION
Fix filename after rename in https://github.com/amaggiulli/QLNet/commit/c0ea99c26b198c04bf51de5dad55394b9debe3e5

QLNet.Old.csproj 's filenames should actually be adjusted for case sensitivity for it to work on Linux/Mono. I'll look into that at a later stage.