### PR TITLE
 Expand BondFunctions::yield to accept dirty price as input too

### DIFF
--- a/src/CallableBonds/CallableBonds.cs
+++ b/src/CallableBonds/CallableBonds.cs
@@ -84,7 +84,7 @@ namespace CallableBonds
          {
             Calendar nullCalendar = new NullCalendar();
 
-            Callability.Price myPrice = new Callability.Price(callPrice, Callability.Price.Type.Clean);
+            Bond.Price myPrice = new Bond.Price(callPrice, Bond.Price.Type.Clean);
             callSchedule.Add(new Callability(myPrice, Callability.Type.Call, callDate));
             callDate = nullCalendar.advance(callDate, 3, TimeUnit.Months);
          }

--- a/src/ConvertibleBonds/ConvertibleBonds.cs
+++ b/src/ConvertibleBonds/ConvertibleBonds.cs
@@ -75,14 +75,14 @@ namespace ConvertibleBonds
             for (int i = 0; i < callLength.Length; i++)
             {
                SoftCallability s = new SoftCallability(
-                  new Callability.Price(callPrices[i], Callability.Price.Type.Clean), schedule.date(callLength[i]),
+                  new Bond.Price(callPrices[i], Bond.Price.Type.Clean), schedule.date(callLength[i]),
                   1.20);
                callability.Add(s);
             }
 
             for (int j = 0; j < putLength.Length; j++)
             {
-               Callability s = new Callability(new Callability.Price(putPrices[j], Callability.Price.Type.Clean),
+               Callability s = new Callability(new Bond.Price(putPrices[j], Bond.Price.Type.Clean),
                                                Callability.Type.Put, schedule.date(putLength[j]));
                callability.Add(s);
             }

--- a/src/QLNet/Instruments/Bond.cs
+++ b/src/QLNet/Instruments/Bond.cs
@@ -33,6 +33,35 @@ namespace QLNet
        - price/yield calculations are checked against known good values. */
    public class Bond : Instrument
    {
+      //! Bond price information
+      public class Price
+      {
+         public enum Type { Dirty, Clean }
+
+         public Price()
+         {
+            amount_ = null;
+         }
+
+         public Price(double amount, Type type)
+         {
+            amount_ = amount;
+            type_ = type;
+         }
+
+         public double amount()
+         {
+            Utils.QL_REQUIRE(amount_ != null, () => "no amount given");
+            return amount_.Value;
+         }
+
+         public Type type() { return type_; }
+
+         private double? amount_;
+         private Type type_;
+      }
+
+
       #region Constructors
       //! constructor for amortizing or non-amortizing bonds.
       /*! Redemptions and maturity are calculated from the coupon

--- a/src/QLNet/Instruments/Bond.cs
+++ b/src/QLNet/Instruments/Bond.cs
@@ -258,14 +258,16 @@ namespace QLNet
 
       //! theoretical bond yield
       /*! The default bond settlement and theoretical price are used for calculation. */
-      public double yield(DayCounter dc, Compounding comp, Frequency freq, double accuracy = 1.0e-8, int maxEvaluations = 100)
+      public double yield(DayCounter dc, Compounding comp, Frequency freq, double accuracy = 1.0e-8, int maxEvaluations = 100, double guess = 0.05, Bond.Price.Type priceType = Price.Type.Clean)
       {
          double currentNotional = notional(settlementDate());
 
          if (currentNotional.IsEqual(0.0))
             return 0.0;
 
-         return BondFunctions.yield(this, cleanPrice(), dc, comp, freq, settlementDate(), accuracy, maxEvaluations);
+         var price = priceType == Price.Type.Clean ? cleanPrice() : dirtyPrice();
+
+         return BondFunctions.yield(this, price, dc, comp, freq, settlementDate(), accuracy, maxEvaluations, guess, priceType);
       }
 
       //! clean price given a yield and settlement date
@@ -288,14 +290,14 @@ namespace QLNet
 
       //! yield given a (clean) price and settlement date
       /*! The default bond settlement is used if no date is given. */
-      public double yield(double cleanPrice, DayCounter dc, Compounding comp, Frequency freq, Date settlement = null,
-                          double accuracy = 1.0e-8, int maxEvaluations = 100)
+      public double yield(double price, DayCounter dc, Compounding comp, Frequency freq, Date settlement = null,
+                          double accuracy = 1.0e-8, int maxEvaluations = 100, double guess = 0.05, Bond.Price.Type priceType = Price.Type.Clean)
       {
          double currentNotional = notional(settlement);
          if (currentNotional.IsEqual(0.0))
             return 0.0;
 
-         return BondFunctions.yield(this, cleanPrice, dc, comp, freq, settlement, accuracy, maxEvaluations);
+         return BondFunctions.yield(this, price, dc, comp, freq, settlement, accuracy, maxEvaluations, guess, priceType);
       }
 
       //! accrued amount at a given date

--- a/src/QLNet/Instruments/Bonds/CallableBond.cs
+++ b/src/QLNet/Instruments/Bonds/CallableBond.cs
@@ -539,7 +539,7 @@ namespace QLNet
                arguments.callabilityDates.Add(putCallSchedule_[i].date());
                arguments.callabilityPrices.Add(putCallSchedule_[i].price().amount());
 
-               if (putCallSchedule_[i].price().type() == Callability.Price.Type.Clean)
+               if (putCallSchedule_[i].price().type() == Bond.Price.Type.Clean)
                {
                   /* calling accrued() forces accrued interest to be zero
                      if future option date is also coupon date, so that dirty

--- a/src/QLNet/Instruments/Bonds/ConvertibleBond.cs
+++ b/src/QLNet/Instruments/Bonds/ConvertibleBond.cs
@@ -25,7 +25,7 @@ namespace QLNet
    //! %callability leaving to the holder the possibility to convert
    public class SoftCallability : Callability
    {
-      public SoftCallability(Callability.Price price, Date date, double trigger)
+      public SoftCallability(Bond.Price price, Date date, double trigger)
          : base(price, Callability.Type.Call, date)
       {
          trigger_ = trigger;
@@ -165,7 +165,7 @@ namespace QLNet
                   moreArgs.callabilityTypes.Add(callability_[i].type());
                   moreArgs.callabilityDates.Add(callability_[i].date());
 
-                  if (callability_[i].price().type() == Callability.Price.Type.Clean)
+                  if (callability_[i].price().type() == Bond.Price.Type.Clean)
                      moreArgs.callabilityPrices.Add(callability_[i].price().amount() +
                                                     bond_.accruedAmount(callability_[i].date()));
                   else

--- a/src/QLNet/Instruments/Callability.cs
+++ b/src/QLNet/Instruments/Callability.cs
@@ -23,44 +23,17 @@ namespace QLNet
    //! %instrument callability
    public class Callability : Event
    {
-      //! amount to be paid upon callability
-      public class Price
-      {
-         public enum Type { Dirty, Clean }
-
-         public Price()
-         {
-            amount_ = null;
-         }
-
-         public Price(double amount, Type type)
-         {
-            amount_ = amount;
-            type_ = type;
-         }
-
-         public double amount()
-         {
-            Utils.QL_REQUIRE(amount_ != null, () => "no amount given");
-            return amount_.Value;
-         }
-
-         public Type type()  { return type_; }
-
-         private double? amount_;
-         private Type type_;
-      }
 
       //! type of the callability
       public enum Type { Call, Put }
 
-      public Callability(Price price, Type type, Date date)
+      public Callability(Bond.Price price, Type type, Date date)
       {
          price_ = price;
          type_ = type;
          date_ = date;
       }
-      public Price price()
+      public Bond.Price price()
       {
          Utils.QL_REQUIRE(price_ != null, () => "no price given");
          return price_;
@@ -69,7 +42,7 @@ namespace QLNet
       // Event interface
       public override Date date() { return date_; }
 
-      private Price price_;
+      private Bond.Price price_;
       private Type type_;
       private Date date_;
 

--- a/src/QLNet/Pricingengines/Bond/BondFunctions.cs
+++ b/src/QLNet/Pricingengines/Bond/BondFunctions.cs
@@ -325,8 +325,9 @@ namespace QLNet
       {
          return bps(bond, new InterestRate(yield, dayCounter, compounding, frequency), settlementDate);
       }
-      public static double yield(Bond bond, double cleanPrice, DayCounter dayCounter, Compounding compounding, Frequency frequency,
-                                 Date settlementDate = null, double accuracy = 1.0e-10, int maxIterations = 100, double guess = 0.05)
+      public static double yield(Bond bond, double price, DayCounter dayCounter, Compounding compounding, Frequency frequency,
+                                 Date settlementDate = null, double accuracy = 1.0e-10, int maxIterations = 100, double guess = 0.05,
+                                 Bond.Price.Type priceType = Bond.Price.Type.Clean)
       {
          if (settlementDate == null)
             settlementDate = bond.settlementDate();
@@ -336,7 +337,11 @@ namespace QLNet
                           " (maturity being " + bond.maturityDate() + ")",
                           QLNetExceptionEnum.NotTradableException);
 
-         double dirtyPrice = cleanPrice + bond.accruedAmount(settlementDate);
+         double dirtyPrice = price;
+
+         if (priceType == Bond.Price.Type.Clean)
+            dirtyPrice += bond.accruedAmount(settlementDate);
+
          dirtyPrice /= 100.0 / bond.notional(settlementDate);
 
          return CashFlows.yield(bond.cashflows(), dirtyPrice,

--- a/src/QLNet/Termstructures/Yield/FittedBondDiscountCurve.cs
+++ b/src/QLNet/Termstructures/Yield/FittedBondDiscountCurve.cs
@@ -263,7 +263,7 @@ namespace QLNet
                      double tenor = dc.yearFraction(refDate, cf[k].date());
                      modelPrice += cf[k].amount() * fittingMethod_.discountFunction(x, tenor);
                   }
-                  if (helper.useCleanPrice())
+                  if (helper.priceType() == Bond.Price.Type.Clean)
                      modelPrice -= bond.accruedAmount(bondSettlement);
 
                   // adjust price (NPV) for forward settlement

--- a/tests/QLNet.Tests/T_Bonds.cs
+++ b/tests/QLNet.Tests/T_Bonds.cs
@@ -134,7 +134,7 @@ namespace TestSuite
 
                            double price = bond.cleanPrice(yields[m], bondDayCount, compounding[n], frequencies[l]);
                            double calculated = bond.yield(price, bondDayCount, compounding[n], frequencies[l], null,
-                                                          tolerance, maxEvaluations);
+                                                          tolerance, maxEvaluations, 0.05, Bond.Price.Type.Clean);
 
                            if (Math.Abs(yields[m] - calculated) > tolerance)
                            {
@@ -151,7 +151,30 @@ namespace TestSuite
                                               + (compounding[n] == Compounding.Compounded ? "compounded" : "continuous") + "\n"
                                               + "    price:  " + price + "\n"
                                               + "    yield': " + calculated + "\n"
-                                              + "    price': " + price2);
+                                              + "    clean price': " + price2);
+                              }
+                           }
+
+                           price = bond.dirtyPrice(yields[m], bondDayCount, compounding[n], frequencies[l]);
+                           calculated = bond.yield(price, bondDayCount, compounding[n], frequencies[l], null,
+                                                   tolerance, maxEvaluations, 0.05, Bond.Price.Type.Dirty);
+
+                           if (Math.Abs(yields[m] - calculated) > tolerance)
+                           {
+                              // the difference might not matter
+                              double price2 = bond.dirtyPrice(calculated, bondDayCount, compounding[n], frequencies[l]);
+                              if (Math.Abs(price - price2) / price > tolerance)
+                              {
+                                 QAssert.Fail("yield recalculation failed:\n"
+                                              + "    issue:     " + issue + "\n"
+                                              + "    maturity:  " + maturity + "\n"
+                                              + "    coupon:    " + coupons[k] + "\n"
+                                              + "    frequency: " + frequencies[l] + "\n\n"
+                                              + "    yield:  " + yields[m] + " "
+                                              + (compounding[n] == Compounding.Compounded ? "compounded" : "continuous") + "\n"
+                                              + "    price:  " + price + "\n"
+                                              + "    yield': " + calculated + "\n"
+                                              + "    dirty price': " + price2);
                               }
                            }
                         }


### PR DESCRIPTION
This PR ports the changes made on the other side and enhances the yield() methods to accept both clean and dirty prices.