### PR TITLE
Fixing QLNet.Old build.

### DIFF
--- a/src/QLNet/Instruments/CouponConversionSchedule.cs
+++ b/src/QLNet/Instruments/CouponConversionSchedule.cs
@@ -28,7 +28,10 @@ namespace QLNet
 
       public DateTime Date { get; set; }
       public double Rate { get; set; }
-      public override string ToString() => ($"Conversion Date : {Date}\nConversion Rate : {Rate}");
+      public override string ToString()
+      {
+         return (string.Format("Conversion Date : {0}\nConversion Rate : {1}", Date, Rate));
+      }
    }
 
    public class CouponConversionSchedule : List<CouponConversion>

--- a/src/QLNet/Math/Optimization/LevenbergMarquardt.cs
+++ b/src/QLNet/Math/Optimization/LevenbergMarquardt.cs
@@ -98,7 +98,7 @@ namespace QLNet
 
          // requirements; check here to get more detailed error messages.
          Utils.QL_REQUIRE(n > 0, () => "no variables given");
-         Utils.QL_REQUIRE(m >= n, () => $"less functions ({m}) than available variables ({n})");
+         Utils.QL_REQUIRE(m >= n, () => string.Format("less functions ({0}) than available variables ({1})", m, n));
          Utils.QL_REQUIRE(endCriteria.functionEpsilon() >= 0.0, () => "negative f tolerance");
          Utils.QL_REQUIRE(xtol_ >= 0.0, () => "negative x tolerance");
          Utils.QL_REQUIRE(gtol_ >= 0.0, () => "negative g tolerance");

--- a/tests/QLNet.Tests.Old/AssemblyInfo.cs
+++ b/tests/QLNet.Tests.Old/AssemblyInfo.cs
@@ -1,7 +1,7 @@
 ﻿using System.Reflection;
 using System.Runtime.InteropServices;
 
-#if ! NET40 || NET45
+#if ! NET452
 using Xunit;
 [assembly: CollectionBehavior(DisableTestParallelization = true)]
 #endif

--- a/tests/QLNet.Tests.Old/QLNet.Tests.Old.csproj
+++ b/tests/QLNet.Tests.Old/QLNet.Tests.Old.csproj
@@ -1,5 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\..\packages\Microsoft.NET.Test.Sdk.16.5.0\build\net40\Microsoft.NET.Test.Sdk.props" Condition="Exists('..\..\packages\Microsoft.NET.Test.Sdk.16.5.0\build\net40\Microsoft.NET.Test.Sdk.props')" />
+  <Import Project="..\..\packages\MSTest.TestAdapter.2.1.1\build\net45\MSTest.TestAdapter.props" Condition="Exists('..\..\packages\MSTest.TestAdapter.2.1.1\build\net45\MSTest.TestAdapter.props')" />
   <Import Project="..\..\packages\MSTest.TestAdapter.1.4.0\build\netcoreapp1.0\MSTest.TestAdapter.props" Condition="Exists('..\..\packages\MSTest.TestAdapter.1.4.0\build\netcoreapp1.0\MSTest.TestAdapter.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -196,12 +198,31 @@
     <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <Private>False</Private>
     </Reference>
+    <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <HintPath>..\..\packages\MSTest.TestFramework.2.1.1\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <HintPath>..\..\packages\MSTest.TestFramework.2.1.1\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data" />
     <Reference Include="System.Numerics" />
     <Reference Include="System.XML" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105.The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\..\packages\MSTest.TestAdapter.2.1.1\build\net45\MSTest.TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\MSTest.TestAdapter.2.1.1\build\net45\MSTest.TestAdapter.props'))" />
+    <Error Condition="!Exists('..\..\packages\MSTest.TestAdapter.2.1.1\build\net45\MSTest.TestAdapter.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\MSTest.TestAdapter.2.1.1\build\net45\MSTest.TestAdapter.targets'))" />
+    <Error Condition="!Exists('..\..\packages\Microsoft.NET.Test.Sdk.16.5.0\build\net40\Microsoft.NET.Test.Sdk.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.NET.Test.Sdk.16.5.0\build\net40\Microsoft.NET.Test.Sdk.props'))" />
+    <Error Condition="!Exists('..\..\packages\Microsoft.NET.Test.Sdk.16.5.0\build\net40\Microsoft.NET.Test.Sdk.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.NET.Test.Sdk.16.5.0\build\net40\Microsoft.NET.Test.Sdk.targets'))" />
+  </Target>
+  <Import Project="..\..\packages\MSTest.TestAdapter.2.1.1\build\net45\MSTest.TestAdapter.targets" Condition="Exists('..\..\packages\MSTest.TestAdapter.2.1.1\build\net45\MSTest.TestAdapter.targets')" />
+  <Import Project="..\..\packages\Microsoft.NET.Test.Sdk.16.5.0\build\net40\Microsoft.NET.Test.Sdk.targets" Condition="Exists('..\..\packages\Microsoft.NET.Test.Sdk.16.5.0\build\net40\Microsoft.NET.Test.Sdk.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/tests/QLNet.Tests.Old/packages.config
+++ b/tests/QLNet.Tests.Old/packages.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Microsoft.NET.Test.Sdk" version="16.5.0" targetFramework="net452" />
+  <package id="MSTest.TestAdapter" version="2.1.1" targetFramework="net452" />
+  <package id="MSTest.TestFramework" version="2.1.1" targetFramework="net452" />
+</packages>


### PR DESCRIPTION
This should get the QLNet.old sln building on the last few versions of Visual Studio.