### PR TITLE
Make helper classes internal

### DIFF
--- a/src/QLNet/Extensions/DoubleExtension.cs
+++ b/src/QLNet/Extensions/DoubleExtension.cs
@@ -17,7 +17,7 @@ using System;
 
 namespace QLNet
 {
-   public static class DoubleExtension
+   internal static class DoubleExtension
    {
       // Fix double comparison
       public static bool IsEqual(this double d1, double d2)

--- a/src/QLNet/Extensions/ListExtension.cs
+++ b/src/QLNet/Extensions/ListExtension.cs
@@ -5,7 +5,7 @@ using System.Text;
 
 namespace QLNet
 {
-   public static class ListExtension
+   internal static class ListExtension
    {
       //    list: List<T> to resize
       //    size: desired new size

--- a/src/QLNet/QLNet.csproj
+++ b/src/QLNet/QLNet.csproj
@@ -18,6 +18,12 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+      <_Parameter1>$(AssemblyName).Tests</_Parameter1>
+    </AssemblyAttribute>
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="System.Reflection.Emit.Lightweight" Version="4.3.0" />
   </ItemGroup>
 


### PR DESCRIPTION
Utility/helper classes (especially those with extension methods) in QLNet should be internal and not be exposed public, else it can cause conflicts with similarly named classes/methods in other libraries.

This PR is a draft, and so far I've identified only these 2 classes that I feel should be internal. However, for the tests to pass, the internal classes should be made visible to the QLNet.Tests project, hence the `.csproj` modification.

I want to add more classes / methods too. One major conflict that I keep encountering is `Utils.ForEach`. It often conflicts with the `ForEach` extension method from the popular `MoreLinq` library. I think `Utils.ForEach` should be internal too, as it's used only for QLNet's purposes. However, I want to test your opinion on whether the entire `Utils` class should be internal. There is a case to be made for some of `Utils`'s methods to be public, but only if they related directly to QLNet and help with the construction of modification of QLNet entities. What's your opinion on this?