### PR TITLE
Project reference to QLNet in samples and consolidated props file

### DIFF
--- a/QLNet.props
+++ b/QLNet.props
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project>
+  <PropertyGroup>
+    <Authors>Andrea Maggiulli</Authors>
+    <Description>A free/open-source library for quantitative finance</Description>
+    <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
+    <Copyright>Copyright (c) 2008-2020 Andrea Maggiulli (a.maggiulli@gmail.com)</Copyright>
+    <PackageTags>QLNet QuantLib quantitative finance financial</PackageTags>
+    <PackageProjectUrl>http://github.com/amaggiulli/qlnet</PackageProjectUrl>
+    <PackageLicenseExpression>BSD-3-Clause</PackageLicenseExpression>
+
+    <VersionPrefix>1.11.4</VersionPrefix>
+    <PackageVersion>1.11.4</PackageVersion>
+  </PropertyGroup>
+</Project>

--- a/QLNet.sln
+++ b/QLNet.sln
@@ -11,6 +11,11 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "QLNet", "src\QLNet\QLNet.cs
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "QLNet.Tests", "tests\QLNet.Tests\QLNet.Tests.csproj", "{5D0C9349-1A5B-455F-9485-0EF4860C8F62}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "solution", "solution", "{8A7E3CEE-5B57-4D14-BDA4-8D09DFF5C909}"
+	ProjectSection(SolutionItems) = preProject
+		QLNet.props = QLNet.props
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/samples/BermudanSwaption/BermudanSwaption.csproj
+++ b/samples/BermudanSwaption/BermudanSwaption.csproj
@@ -1,7 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), QLNet.sln))\QLNet.props" />
+
   <PropertyGroup>
-    <VersionPrefix>1.11.4</VersionPrefix>
     <TargetFrameworks>netcoreapp2.2</TargetFrameworks>
     <DefineConstants>$(DefineConstants);QL_NEGATIVE_RATES</DefineConstants>
     <AssemblyName>BermudanSwaption</AssemblyName>

--- a/samples/BermudanSwaption/BermudanSwaption.csproj
+++ b/samples/BermudanSwaption/BermudanSwaption.csproj
@@ -12,7 +12,7 @@
   </PropertyGroup>
  
   <ItemGroup>
-    <PackageReference Include="QLNet" Version="1.11.4" />
+    <ProjectReference Include="..\..\src\QLNet\QLNet.csproj" />
   </ItemGroup>
 
 </Project>

--- a/samples/Bonds/Bonds.csproj
+++ b/samples/Bonds/Bonds.csproj
@@ -12,7 +12,7 @@
   </PropertyGroup>
  
   <ItemGroup>
-    <PackageReference Include="QLNet" Version="1.11.4" />
+    <ProjectReference Include="..\..\src\QLNet\QLNet.csproj" />
   </ItemGroup>
 
 </Project>

--- a/samples/Bonds/Bonds.csproj
+++ b/samples/Bonds/Bonds.csproj
@@ -1,7 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), QLNet.sln))\QLNet.props" />
+
   <PropertyGroup>
-    <VersionPrefix>1.11.4</VersionPrefix>
     <TargetFrameworks>netcoreapp2.2</TargetFrameworks>
     <DefineConstants>$(DefineConstants);QL_NEGATIVE_RATES</DefineConstants>
     <AssemblyName>Bonds</AssemblyName>

--- a/samples/CVAIRS/CVAIRS.csproj
+++ b/samples/CVAIRS/CVAIRS.csproj
@@ -12,7 +12,7 @@
   </PropertyGroup>
  
   <ItemGroup>
-    <PackageReference Include="QLNet" Version="1.11.4" />
+    <ProjectReference Include="..\..\src\QLNet\QLNet.csproj" />
   </ItemGroup>
 
 </Project>

--- a/samples/CVAIRS/CVAIRS.csproj
+++ b/samples/CVAIRS/CVAIRS.csproj
@@ -1,7 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), QLNet.sln))\QLNet.props" />
+
   <PropertyGroup>
-    <VersionPrefix>1.11.4</VersionPrefix>
     <TargetFrameworks>netcoreapp2.2</TargetFrameworks>
     <DefineConstants>$(DefineConstants);QL_NEGATIVE_RATES</DefineConstants>
     <AssemblyName>CVAIRS</AssemblyName>

--- a/samples/CallableBonds/CallableBonds.csproj
+++ b/samples/CallableBonds/CallableBonds.csproj
@@ -12,7 +12,7 @@
   </PropertyGroup>
  
   <ItemGroup>
-    <PackageReference Include="QLNet" Version="1.11.4" />
+    <ProjectReference Include="..\..\src\QLNet\QLNet.csproj" />
   </ItemGroup>
 
 </Project>

--- a/samples/CallableBonds/CallableBonds.csproj
+++ b/samples/CallableBonds/CallableBonds.csproj
@@ -1,7 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), QLNet.sln))\QLNet.props" />
+
   <PropertyGroup>
-    <VersionPrefix>1.11.4</VersionPrefix>
     <TargetFrameworks>netcoreapp2.2</TargetFrameworks>
     <DefineConstants>$(DefineConstants);QL_NEGATIVE_RATES</DefineConstants>
     <AssemblyName>CallableBonds</AssemblyName>

--- a/samples/ConvertibleBonds/ConvertibleBonds.csproj
+++ b/samples/ConvertibleBonds/ConvertibleBonds.csproj
@@ -12,7 +12,7 @@
   </PropertyGroup>
  
   <ItemGroup>
-    <PackageReference Include="QLNet" Version="1.11.4" />
+    <ProjectReference Include="..\..\src\QLNet\QLNet.csproj" />
   </ItemGroup>
 
 </Project>

--- a/samples/ConvertibleBonds/ConvertibleBonds.csproj
+++ b/samples/ConvertibleBonds/ConvertibleBonds.csproj
@@ -1,7 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), QLNet.sln))\QLNet.props" />
+
   <PropertyGroup>
-    <VersionPrefix>1.11.3</VersionPrefix>
     <TargetFrameworks>netcoreapp2.2</TargetFrameworks>
     <DefineConstants>$(DefineConstants);QL_NEGATIVE_RATES</DefineConstants>
     <AssemblyName>ConvertibleBonds</AssemblyName>

--- a/samples/EquityOption/EquityOption.csproj
+++ b/samples/EquityOption/EquityOption.csproj
@@ -12,7 +12,7 @@
   </PropertyGroup>
  
   <ItemGroup>
-    <PackageReference Include="QLNet" Version="1.11.4" />
+    <ProjectReference Include="..\..\src\QLNet\QLNet.csproj" />
   </ItemGroup>
 
 </Project>

--- a/samples/EquityOption/EquityOption.csproj
+++ b/samples/EquityOption/EquityOption.csproj
@@ -1,7 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), QLNet.sln))\QLNet.props" />
+
   <PropertyGroup>
-    <VersionPrefix>1.11.4</VersionPrefix>
     <TargetFrameworks>netcoreapp2.2</TargetFrameworks>
     <DefineConstants>$(DefineConstants);QL_NEGATIVE_RATES</DefineConstants>
     <AssemblyName>EquityOption</AssemblyName>

--- a/samples/FRA/FRA.csproj
+++ b/samples/FRA/FRA.csproj
@@ -12,7 +12,7 @@
   </PropertyGroup>
  
   <ItemGroup>
-    <PackageReference Include="QLNet" Version="1.11.4" />
+    <ProjectReference Include="..\..\src\QLNet\QLNet.csproj" />
   </ItemGroup>
 
 </Project>

--- a/samples/FRA/FRA.csproj
+++ b/samples/FRA/FRA.csproj
@@ -1,7 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), QLNet.sln))\QLNet.props" />
+
   <PropertyGroup>
-    <VersionPrefix>1.11.4</VersionPrefix>
     <TargetFrameworks>netcoreapp2.2</TargetFrameworks>
     <DefineConstants>$(DefineConstants);QL_NEGATIVE_RATES</DefineConstants>
     <AssemblyName>FRA</AssemblyName>

--- a/samples/FittedBondCurve/FittedBondCurve.csproj
+++ b/samples/FittedBondCurve/FittedBondCurve.csproj
@@ -12,7 +12,7 @@
   </PropertyGroup>
  
   <ItemGroup>
-    <PackageReference Include="QLNet" Version="1.11.4" />
+    <ProjectReference Include="..\..\src\QLNet\QLNet.csproj" />
   </ItemGroup>
 
 </Project>

--- a/samples/FittedBondCurve/FittedBondCurve.csproj
+++ b/samples/FittedBondCurve/FittedBondCurve.csproj
@@ -1,7 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), QLNet.sln))\QLNet.props" />
+
   <PropertyGroup>
-    <VersionPrefix>1.11.4</VersionPrefix>
     <TargetFrameworks>netcoreapp2.2</TargetFrameworks>
     <DefineConstants>$(DefineConstants);QL_NEGATIVE_RATES</DefineConstants>
     <AssemblyName>FittedBondCurve</AssemblyName>

--- a/samples/QLNetSamples.sln
+++ b/samples/QLNetSamples.sln
@@ -23,6 +23,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Repo", "Repo\Repo.csproj", 
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Swap", "Swap\Swap.csproj", "{8B065C68-3BF3-4B62-9CFB-8A8B8084DB10}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "QLNet", "..\src\QLNet\QLNet.csproj", "{8A8AAD1A-4D54-4D70-82D1-DD50DD910421}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -69,6 +71,10 @@ Global
 		{8B065C68-3BF3-4B62-9CFB-8A8B8084DB10}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{8B065C68-3BF3-4B62-9CFB-8A8B8084DB10}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{8B065C68-3BF3-4B62-9CFB-8A8B8084DB10}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8A8AAD1A-4D54-4D70-82D1-DD50DD910421}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8A8AAD1A-4D54-4D70-82D1-DD50DD910421}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8A8AAD1A-4D54-4D70-82D1-DD50DD910421}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8A8AAD1A-4D54-4D70-82D1-DD50DD910421}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/samples/Repo/Repo.csproj
+++ b/samples/Repo/Repo.csproj
@@ -12,7 +12,7 @@
   </PropertyGroup>
  
   <ItemGroup>
-    <PackageReference Include="QLNet" Version="1.11.4" />
+    <ProjectReference Include="..\..\src\QLNet\QLNet.csproj" />
   </ItemGroup>
 
 </Project>

--- a/samples/Repo/Repo.csproj
+++ b/samples/Repo/Repo.csproj
@@ -1,7 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), QLNet.sln))\QLNet.props" />
+
   <PropertyGroup>
-    <VersionPrefix>1.11.4</VersionPrefix>
     <TargetFrameworks>netcoreapp2.2</TargetFrameworks>
     <DefineConstants>$(DefineConstants);QL_NEGATIVE_RATES</DefineConstants>
     <AssemblyName>Repo</AssemblyName>

--- a/samples/Swap/Swap.csproj
+++ b/samples/Swap/Swap.csproj
@@ -12,7 +12,7 @@
   </PropertyGroup>
  
   <ItemGroup>
-    <PackageReference Include="QLNet" Version="1.11.4" />
+    <ProjectReference Include="..\..\src\QLNet\QLNet.csproj" />
   </ItemGroup>
 
 </Project>

--- a/samples/Swap/Swap.csproj
+++ b/samples/Swap/Swap.csproj
@@ -1,7 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), QLNet.sln))\QLNet.props" />
+
   <PropertyGroup>
-    <VersionPrefix>1.11.4</VersionPrefix>
     <TargetFrameworks>netcoreapp2.2</TargetFrameworks>
     <DefineConstants>$(DefineConstants);QL_NEGATIVE_RATES</DefineConstants>
     <AssemblyName>Swap</AssemblyName>

--- a/src/QLNet/QLNet.csproj
+++ b/src/QLNet/QLNet.csproj
@@ -1,19 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), QLNet.sln))\QLNet.props" />
+
   <PropertyGroup>
-    <VersionPrefix>1.11.4</VersionPrefix>
     <TargetFrameworks>netstandard1.2</TargetFrameworks>
     <DefineConstants>$(DefineConstants);QL_NEGATIVE_RATES</DefineConstants>
     <AssemblyName>QLNet</AssemblyName>
     <PackageId>QLNet</PackageId>
-    <PackageVersion>1.11.4</PackageVersion>
-    <Authors>Andrea Maggiulli</Authors>
-    <Company />
-    <Description>A free/open-source library for quantitative finance</Description>
-    <Copyright>Copyright (c) 2008-2020 Andrea Maggiulli (a.maggiulli@gmail.com)</Copyright>
-    <PackageLicenseUrl>https://github.com/amaggiulli/QLNet/blob/develop/LICENSE</PackageLicenseUrl>
-    <PackageProjectUrl>http://github.com/amaggiulli/qlnet</PackageProjectUrl>
-    <PackageTags>QLNet QuantLib quantitative finance financial</PackageTags>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
   </PropertyGroup>
 

--- a/tests/QLNet.Tests/QLNet.Tests.csproj
+++ b/tests/QLNet.Tests/QLNet.Tests.csproj
@@ -1,5 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), QLNet.sln))\QLNet.props" />
+
   <PropertyGroup>
     <TargetFrameworks>netcoreapp2.2</TargetFrameworks>
     <LangVersion>latest</LangVersion>


### PR DESCRIPTION
This PR does 2 things

- For the samples projects, changes the QLNet package reference to a project reference. This makes it easier to debug. We can discuss this if you disagree
- Adds a new QLNet.props which contains shared project attributes. Make all projects reference this shared props file