### PR TITLE
Add 2023-12-15 as South African public holiday

### DIFF
--- a/src/QLNet/Time/Calendars/SouthAfrica.cs
+++ b/src/QLNet/Time/Calendars/SouthAfrica.cs
@@ -107,6 +107,8 @@ namespace QLNet
                 || (d == 3 && m == Month.August && y == 2016)
                 // one-shot: In lieu of Christmas falling on Sunday in 2022
                 || (d == 27 && m == Month.December && y == 2022)
+                // one-shot: Special holiday to celebrate winning of Rugby World Cup 2023
+                || (d == 15 && m == Month.December && y == 2023)
                )
                return false;
             return true;


### PR DESCRIPTION
Ad hoc public holiday declare for 15 December 2023 for South Africa. https://www.gov.za/about-sa/public-holidays#2023