### PR TITLE
 Solver1d hardening to improve resolution with case driving to NaN values.

### DIFF
--- a/src/QLNet/Math/Solver1d.cs
+++ b/src/QLNet/Math/Solver1d.cs
@@ -91,6 +91,15 @@ namespace QLNet
             fxMax_ = f.value(xMax_);
          }
 
+         if (double.IsNaN(fxMax_) || double.IsNaN(fxMin_))
+         {
+            Utils.QL_FAIL("unable to bracket root function evaluations (Undefined value on initial bracket: "
+                          + "f[" + xMin_ + "," + xMax_ +
+                          "] "
+                          + "-> [" + fxMin_ + "," + fxMax_ + "])",
+                          QLNetExceptionEnum.RootNotBracketException);
+         }
+
          evaluationNumber_ = 2;
          while (evaluationNumber_ <= maxEvaluations_)
          {
@@ -101,29 +110,37 @@ namespace QLNet
                if (Utils.close(fxMax_, 0.0))
                   return xMax_;
                root_ = (xMax_ + xMin_) / 2.0;
+
+               if (double.IsInfinity(fxMin_) || double.IsInfinity(fxMax_))
+               {
+                  Utils.QL_FAIL("unable to bracket root function evaluations (Undefined value on initial bracket: "
+                          + "f[" + xMin_ + "," + xMax_ +
+                          "] "
+                          + "-> [" + fxMin_ + "," + fxMax_ + "])",
+                          QLNetExceptionEnum.RootNotBracketException);
+               }
+
                return solveImpl(f, accuracy);
             }
             if (Math.Abs(fxMin_) < Math.Abs(fxMax_))
             {
-               xMin_ = enforceBounds_(xMin_ + growthFactor * (xMin_ - xMax_));
-               fxMin_ = f.value(xMin_);
+               (xMin_, fxMin_) = computeGrowthStep(f, xMin_, enforceBounds_(xMin_ + growthFactor * (xMin_ - xMax_)));
             }
             else if (Math.Abs(fxMin_) > Math.Abs(fxMax_))
             {
-               xMax_ = enforceBounds_(xMax_ + growthFactor * (xMax_ - xMin_));
-               fxMax_ = f.value(xMax_);
+               (xMax_, fxMax_) = computeGrowthStep(f, xMax_, enforceBounds_(xMax_ + growthFactor * (xMax_ - xMin_)));
             }
             else if (flipflop == -1)
             {
-               xMin_ = enforceBounds_(xMin_ + growthFactor * (xMin_ - xMax_));
-               fxMin_ = f.value(xMin_);
+               (xMin_, fxMin_) = computeGrowthStep(f, xMin_, enforceBounds_(xMin_ + growthFactor * (xMin_ - xMax_)));
+
                evaluationNumber_++;
                flipflop = 1;
             }
             else if (flipflop == 1)
             {
-               xMax_ = enforceBounds_(xMax_ + growthFactor * (xMax_ - xMin_));
-               fxMax_ = f.value(xMax_);
+               (xMax_, fxMax_) = computeGrowthStep(f, xMax_, enforceBounds_(xMax_ + growthFactor * (xMax_ - xMin_)));
+
                flipflop = -1;
             }
             evaluationNumber_++;
@@ -210,6 +227,21 @@ namespace QLNet
          if (lowerBoundEnforced_ && x < lowerBound_) return lowerBound_;
          if (upperBoundEnforced_ && x > upperBound_) return upperBound_;
          return x;
+      }
+
+      private (double x, double fx) computeGrowthStep(ISolver1d f, double previousX, double x)
+      {
+         double fx = f.value(x);
+
+         while (double.IsNaN(fx) && Math.Abs(x - previousX) > double.Epsilon && evaluationNumber_ <= maxEvaluations_)
+         {
+            x = (x + previousX) / 2;
+            fx = f.value(x);
+
+            evaluationNumber_++;
+         }
+
+         return (x, fx);
       }
 
       protected abstract double solveImpl(ISolver1d f, double xAccuracy);

--- a/tests/QLNet.Tests/T_Bonds.cs
+++ b/tests/QLNet.Tests/T_Bonds.cs
@@ -1902,8 +1902,49 @@ namespace TestSuite
       }
 
       [Theory]
-      [InlineData(1.850, "11/23/2015", "11/23/2018", "11/23/2018", "5/23/2016", 100.8547)]
       [InlineData(2.200, "10/22/2014", "10/22/2019", "12/24/2018", "4/22/2015", 994.263)]
+      public void testSolverNaNCase(double Coupon,
+                                      string AccrualDate, string MaturityDate, string SettlementDate,
+                                      string FirstCouponDate, double Price)
+      {
+         // Convert dates
+         Date maturityDate = Convert.ToDateTime(MaturityDate, new CultureInfo("en-US"));
+         Date settlementDate = Convert.ToDateTime(SettlementDate, new CultureInfo("en-US"));
+         Date datedDate = Convert.ToDateTime(AccrualDate, new CultureInfo("en-US"));
+         Date firstCouponDate = null;
+         if (FirstCouponDate != String.Empty)
+            firstCouponDate = Convert.ToDateTime(FirstCouponDate, new CultureInfo("en-US"));
+
+         Coupon = Coupon / 100;
+
+         Calendar calendar = new TARGET();
+         int settlementDays = 0;
+         Period tenor = new Period(6, TimeUnit.Months);
+         Compounding comp = Compounding.Compounded;
+         Frequency freq = Frequency.Semiannual;
+         DayCounter dc = new Thirty360(Thirty360.Thirty360Convention.USA);
+
+         Schedule schedule = new Schedule(datedDate, maturityDate, tenor, calendar,
+                                          BusinessDayConvention.Unadjusted, BusinessDayConvention.Unadjusted,
+                                          DateGeneration.Rule.Backward, false, firstCouponDate);
+
+         CallableFixedRateBond bond = new CallableFixedRateBond(settlementDays, 100.0, schedule,
+                                                                new InitializedList<double>(1, Coupon), dc, BusinessDayConvention.Unadjusted);
+
+         double ytm = BondFunctions.yield(bond, Price, dc, comp, freq, settlementDate);
+
+         double price = BondFunctions.cleanPrice(bond, ytm, dc, comp, freq, settlementDate);
+
+         if (Math.Abs(price - Price) > 1e-2)
+            QAssert.Fail("Failed to retrieve the clean price from the computed yield " + settlementDate
+                         + "\n    calculated yield: " + ytm
+                         + "\n    retrieved clean price: " + price
+                         + "\n    expected:   " + Price);
+      }
+
+      [Theory]
+      [InlineData(1.850, "11/23/2015", "11/23/2018", "11/23/2018", "5/23/2016", 100.8547)]
+      [InlineData(2.200, "10/22/2014", "10/22/2019", "10/01/2019", "4/22/2015", 994.263)]
       public void testQLNetExceptions(double Coupon,
                                       string AccrualDate, string MaturityDate, string SettlementDate,
                                       string FirstCouponDate, double Price)

--- a/tests/QLNet.Tests/T_Solvers.cs
+++ b/tests/QLNet.Tests/T_Solvers.cs
@@ -87,5 +87,117 @@ namespace TestSuite
       {
          test(new Secant(), "Secant");
       }
+
+      class NanSolver : ISolver1d
+      {
+         public override double value(double x) { return (x < 1.25) ? double.NaN : x * x - 1.60; }
+         public override double derivative(double x) { return 2.0 * x; }
+      }
+
+      internal void testNan(Solver1D solver, string name)
+      {
+         double[] accuracy = new double[] { 1.0e-3, 1.0e-4, 1.0e-6 };
+         double expected = 1.2649110986579275;
+         for (int i = 0; i < accuracy.Length; i++)
+         {
+            double root = solver.solve(new NanSolver(), accuracy[i], 1.5, 0.1);
+            //double root = solver.solve(new NanSolver(), accuracy[i], 0.5, 0.1);
+            if (Math.Abs(root - expected) > accuracy[i])
+            {
+               QAssert.Fail(name + " solver:\n"
+                            + "    expected:   " + expected + "\n"
+                            + "    calculated: " + root + "\n"
+                            + "    accuracy:   " + accuracy[i]);
+            }
+            root = solver.solve(new NanSolver(), accuracy[i], 1.5, 1.25, 2.0);
+            if (Math.Abs(root - expected) > accuracy[i])
+            {
+               QAssert.Fail(name + " solver (bracketed):\n"
+                            + "    expected:   " + expected + "\n"
+                            + "    calculated: " + root + "\n"
+                            + "    accuracy:   " + accuracy[i]);
+            }
+         }
+      }
+
+      internal void testNanExceptionByStep(Solver1D solver, string name)
+      {
+         double accuracy = 1.0e-6;
+
+         try
+         {
+            double root = solver.solve(new NanSolver(), accuracy, 0.5, 0.1);
+         }
+         catch (RootNotBracketException)
+         {
+            return;
+         }
+         catch (Exception)
+         {
+            QAssert.Fail("Failed to handle QLNet exception");
+
+            throw;
+         }
+
+         QAssert.Fail("Failed to capture QLNet exception");
+      }
+
+      internal void testNanExceptionByRange(Solver1D solver, string name)
+      {
+         double accuracy = 1.0e-6;
+
+         try
+         {
+            double root = solver.solve(new NanSolver(), accuracy, 0.5, 0.0, 1.0);
+         }
+         catch (ArgumentException)
+         {
+            return;
+         }
+         catch (Exception)
+         {
+            QAssert.Fail("Failed to handle QLNet exception");
+
+            throw;
+         }
+
+         QAssert.Fail("Failed to capture QLNet exception");
+      }
+
+      [Fact]
+      public void testNanBrent()
+      {
+         testNan(new Brent(), "Brent");
+      }
+
+      [Fact]
+      public void testNanExceptionByStepBrent()
+      {
+         testNanExceptionByStep(new Brent(), "Brent");
+      }
+
+      [Fact]
+      public void testNanExceptionByRangeBrent()
+      {
+         testNanExceptionByRange(new Brent(), "Brent");
+      }
+
+      [Fact]
+      public void testNanNewton()
+      {
+         testNan(new Newton(), "Newton");
+      }
+
+      [Fact]
+      public void testNanExceptionByStepNewton()
+      {
+         testNanExceptionByStep(new Newton(), "Newton");
+      }
+
+      [Fact]
+      public void testNanExceptionByRangeNewton()
+      {
+         testNanExceptionByRange(new Newton(), "Newton");
+      }
    }
 }


### PR DESCRIPTION

 - improve method to bracket root function evaluations.
 - Update T_Bonds tests
 - Add tests in T_Solvers

see issue #300

## QLNet

Thank you for contributing! Take a moment to review our [**contributing guidelines**](https://github.com/amaggiulli/qlnet/blob/develop/.github/CONTRIBUTING.md)
to make the process easy and effective for everyone involved.

**You must open an issue** before embarking on any significant pull request, especially those that
add a new code or change existing tests, otherwise you risk spending a lot of time working
on something that might not end up being merged into the project.

**IMPORTANT**: By submitting a patch via a Pull Request, you agree to allow the project
owners to license your work under the terms of the [BSD3 License](https://github.com/amaggiulli/qlnet/blob/develop/LICENSE).

## PR Type
What kind of change does this PR introduce?
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[X] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[X] Tests
[ ] Other
```

## Description
Solver1d trying to bracket root function evaluations:
- Once the Solver1d reach a NaN value on fxMin_ or fxMax_ try to get back to a real value reducing the growth step on xMin_ or xMax_ and try to find a solution.

