### PR TITLE
[GH-307] CallableBonds : Added yield calculation at any date/price.

### DIFF
--- a/src/QLNet/Instruments/Bonds/CallableBond.cs
+++ b/src/QLNet/Instruments/Bonds/CallableBond.cs
@@ -1,5 +1,5 @@
 ﻿/*
- Copyright (C) 2008-2023  Andrea Maggiulli (a.maggiulli@gmail.com)
+ Copyright (C) 2008-2025  Andrea Maggiulli (a.maggiulli@gmail.com)
 
  This file is part of QLNet Project https://github.com/amaggiulli/qlnet
 
@@ -474,6 +474,46 @@ namespace QLNet
          }
          return cc.ToArray();
       }
+
+      public virtual double yieldAt(Date settlementDate, double price, Frequency frequency, double accuracy,
+         Date? maturityDate = null, double? redemption = null)
+      {
+
+         throw new NotImplementedException("yieldToDate not implemented for the given bond");
+      }
+
+      protected double yieldAtInternal(CouponType couponType, Date settlementDate, double price, Frequency frequency,
+         double accuracy, Date? maturityDate = null, double? redemption = null)
+      {
+         Bond bond = this;
+         if (maturityDate != null && redemption is > 0)
+         {
+            bond = CreateFixedRateBond(maturityDate, redemption.Value, couponType);
+         }
+
+         var comp = GetSecurityCompounding(bond, couponType, settlementDate);
+         return bond.yield(price, paymentDayCounter_, comp, frequency, settlementDate, accuracy);
+      }
+
+      public virtual double priceAt(Date settlementDate, Date? maturityDate, double? redemption, double yield,
+         Frequency frequency)
+      {
+
+         throw new NotImplementedException("yieldToDate not implemented for the given bond");
+      }
+
+      protected double priceAtInternal(CouponType couponType, Date settlementDate, Date? maturityDate, double? redemption, double yield,
+         Frequency frequency)
+      {
+         Bond bond = this;
+         if (maturityDate != null && redemption is > 0)
+         {
+            bond = CreateFixedRateBond(maturityDate, redemption.Value, couponType);
+         }
+         var comp = GetSecurityCompounding(bond, couponType, settlementDate);
+         return bond.cleanPrice(yield, paymentDayCounter_, comp, frequency, settlementDate);
+      }
+
       /// <summary>
       /// helper class for Black implied volatility calculation
       /// </summary>
@@ -666,24 +706,31 @@ namespace QLNet
          for (var i = 0; i < putCallSchedule_.Count; i++)
          {
             var call = putCallSchedule_[i];
-            if (couponType == CouponType.FixedRate)
-            {
-               var fixedRateBondSchedule = mainSchedule_.until(call.date());
-               var fixedRateBondCoupons = coupons_.Take(mainSchedule_.size() - 1).ToList();
-               var bond = new FixedRateBond(settlementDays_, faceAmount_, fixedRateBondSchedule, fixedRateBondCoupons,
-                  paymentDayCounter_, BusinessDayConvention.Unadjusted, call.price().amount(), issueDate_);
-               bonds.Add(bond);
-            }
-            else
-            {
-               var bond = new ZeroCouponBond(settlementDays_, calendar_, faceAmount_, call.date(),
-                  BusinessDayConvention.Unadjusted, call.price().amount(), issueDate_);
-               bonds.Add(bond);
-            }
+            var bond = CreateFixedRateBond(call.date(), call.price().amount(), couponType);
+            bonds.Add(bond);
            
          }
          return bonds.ToArray();
       }
+
+      protected Bond CreateFixedRateBond (Date maturityDate, double redemption, CouponType couponType)
+      {
+         if (couponType == CouponType.FixedRate)
+         {
+            var fixedRateBondSchedule = mainSchedule_.until(maturityDate);
+            var fixedRateBondCoupons = coupons_.Take(mainSchedule_.size() - 1).ToList();
+            var bond = new FixedRateBond(settlementDays_, faceAmount_, fixedRateBondSchedule, fixedRateBondCoupons,
+               paymentDayCounter_, BusinessDayConvention.Unadjusted, redemption, issueDate_);
+            return bond;
+         }
+         else
+         {
+            var bond = new ZeroCouponBond(settlementDays_, calendar_, faceAmount_, maturityDate,
+               BusinessDayConvention.Unadjusted, redemption, issueDate_);
+            return bond;
+         }
+      }
+
       protected Compounding GetSecurityCompounding(Bond bond, CouponType couponType, DateTime settlementDate)
       {
          if (bond.nextCashFlowDate(settlementDate) == bond.maturityDate())
@@ -697,7 +744,7 @@ namespace QLNet
          return Compounding.Compounded;
       }
 
-      protected enum CouponType {FixedRate, ZeroCoupon}
+      public enum CouponType {FixedRate, ZeroCoupon}
 
       public class CallableCalcs
       {
@@ -749,6 +796,12 @@ namespace QLNet
       {
          return priceToCallsInternal(settlement, price, CouponType.FixedRate, frequency);
       }
+
+      public override double yieldAt(Date settlementDate, double price, Frequency frequency, double accuracy,
+         Date? maturityDate = null, double? redemption = null)
+      {
+         return yieldAtInternal(CouponType.FixedRate, settlementDate,price,frequency,accuracy, maturityDate, redemption);
+      }
    }
 
    /// <summary>
@@ -783,6 +836,11 @@ namespace QLNet
          return priceToCallsInternal(settlement, price, CouponType.ZeroCoupon, frequency);
       }
 
+      public override double yieldAt(Date settlementDate, double price, Frequency frequency, double accuracy,
+         Date? maturityDate, double? redemption = null)
+      {
+         return yieldAtInternal(CouponType.ZeroCoupon, settlementDate,price,frequency,accuracy, maturityDate, redemption);
+      }
    }
 
 }

--- a/tests/QLNet.Tests/T_CallableBonds.cs
+++ b/tests/QLNet.Tests/T_CallableBonds.cs
@@ -17,12 +17,13 @@
  FOR A PARTICULAR PURPOSE.  See the license for more details.
 */
 
+using QLNet;
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using Xunit;
 using Xunit.Priority;
-using QLNet;
 
 namespace TestSuite;
 
@@ -30,10 +31,12 @@ namespace TestSuite;
 [TestCaseOrderer(PriorityOrderer.Name, PriorityOrderer.Assembly)]
 public class CallableBondsTests
 {
+   private readonly double _tolerance = 1.0e-3;
+
    public class Globals
    {
       public Date today, settlement;
-      public Calendar calendar;
+      public QLNet.Calendar calendar;
       public DayCounter dayCounter;
       public BusinessDayConvention rollingConvention;
 
@@ -794,6 +797,55 @@ public class CallableBondsTests
       QAssert.AreEqual(expectedPrice, pp[0].CalcPrice);
    }
 
+   [Theory]
+   [InlineData(0, CallableBond.CouponType.ZeroCoupon, "06/01/2061", "09/08/2017", 3.7101424, "02/07/2006", 1.5307142, 7.7, "10/13/2017", 3, 8.2, null, 8.2, null)]
+   [InlineData(5, CallableBond.CouponType.FixedRate, "07/01/2060", "07/01/2025", 100d, "09/09/2015", 103.2828783, 4.58, "10/13/2017", 111.7, 4.391, 3.272, 3.272, null)]
+   [InlineData(5, CallableBond.CouponType.FixedRate, "10/01/2021", "10/01/2020", 100d, "04/21/2010", 114.91, 3.3, "09/07/2018", 106.709, 2.705, 1.683, 1.683, 21.666)]
+   public void testYieldAt(double coupon, CallableBond.CouponType couponType, string MaturityDate, string NextCallDate, double? nextCallPrice,
+                           string AccrualDate, double? originalPrice, decimal originalYield,
+                           string SettlementDate, double price, double expectedYTM, double? expectedYTC,
+                           double expectedYTW, double? expectedAccruedInterest)
+   {
+      var settlementDate = Convert.ToDateTime(SettlementDate, new CultureInfo("en-US"));
+      Settings.setEvaluationDate(settlementDate);
+      Date maturityDate = Convert.ToDateTime(MaturityDate, new CultureInfo("en-US"));
+      Date accrualDate = Convert.ToDateTime(AccrualDate, new CultureInfo("en-US"));
+      var nextCallDate = new Date();
+      if (NextCallDate != "") nextCallDate = Convert.ToDateTime(NextCallDate, new CultureInfo("en-US"));
+      var calendar = new TARGET();
+      var dc = new Thirty360(Thirty360.Thirty360Convention.BondBasis);
+      var frequency = Frequency.Semiannual;
+      var accuracy = 1.0e-06;
+      CallableBond callableBond = null;
 
+      var callSchedule = new CallabilitySchedule
+      {
+         new Callability( new Bond.Price(nextCallPrice.GetValueOrDefault(),Bond.Price.Type.Clean),Callability.Type.Call, nextCallDate),
+      };
 
+      if ( couponType == CallableBond.CouponType.FixedRate)
+      {
+         var sch = new Schedule( accrualDate, maturityDate, new Period(frequency), calendar, BusinessDayConvention.Unadjusted,
+            BusinessDayConvention.Unadjusted, DateGeneration.Rule.Backward, false, null);
+
+         callableBond = new CallableFixedRateBond(0, 1000, sch, [coupon/100], dc, BusinessDayConvention.Unadjusted,
+            100, accrualDate, callSchedule);
+      }
+      else
+      {
+         callableBond = new CallableZeroCouponBond(0, 1000, calendar, maturityDate,dc, BusinessDayConvention.Unadjusted,
+            100, null, callSchedule);
+      }
+
+      var yieldToMaturity = callableBond.yieldAt(settlementDate, price, frequency, accuracy) * 100;
+
+      QAssert.IsTrue(Math.Abs(yieldToMaturity - expectedYTM) <= _tolerance,
+         $"testYieldAt: YTM calculation failed, expected: {expectedYTM}, calculated: {yieldToMaturity}");
+
+      var yieldToCall = callableBond.yieldAt(settlementDate, price, frequency, accuracy, nextCallDate, nextCallPrice) * 100;
+
+      QAssert.IsTrue(Math.Abs(yieldToCall - expectedYTC.GetValueOrDefault()) <= _tolerance,
+         $"testYieldAt: YTC calculation failed, expected: {expectedYTC}, calculated: {yieldToCall}");
+
+   }
 }


### PR DESCRIPTION
## QLNet

## PR Type
What kind of change does this PR introduce?
```
[ ] Bugfix
[x ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Tests
[ ] Other
```

## Description
- Callable Bonds: Building upon the previous update for yield/price calculations at specific call dates, this feature now allows the valuation (yield/price) of callable bonds at any date, dynamically constructing the required fixed-rate bond if needed.