### PR TITLE
[GH-321] Add sinkable support to callable bonds.

### DIFF
--- a/src/QLNet/Instruments/Bonds/CallableBond.cs
+++ b/src/QLNet/Instruments/Bonds/CallableBond.cs
@@ -42,6 +42,9 @@ namespace QLNet
       protected double faceAmount_;
       protected Schedule mainSchedule_;
       protected List<double> coupons_;
+      protected List<double> notionalsByPeriod_;
+      protected bool hasAmortizingSchedule_;
+      protected BusinessDayConvention paymentConvention_;
 
       /// <summary>
       /// Ctor
@@ -124,47 +127,64 @@ namespace QLNet
          arguments.faceAmount = faceAmount_;
          arguments.redemption = redemption().amount();
          arguments.redemptionDate = redemption().date();
-
-         List<CashFlow> cfs = cashflows();
-
-         arguments.couponDates = new List<Date>(cfs.Count - 1);
-         arguments.couponAmounts = new List<double>(cfs.Count - 1);
-
-         for (int i = 0; i < cfs.Count; i++)
-         {
-            if (!cfs[i].hasOccurred(settlement, false))
-            {
-               if (cfs[i] is QLNet.FixedRateCoupon)
-               {
-                  arguments.couponDates.Add(cfs[i].date());
-                  arguments.couponAmounts.Add(cfs[i].amount());
-               }
-            }
-         }
-
          arguments.callabilityPrices = new List<double>(putCallSchedule_.Count);
          arguments.callabilityDates = new List<Date>(putCallSchedule_.Count);
          arguments.paymentDayCounter = paymentDayCounter_;
          arguments.frequency = frequency_;
          arguments.putCallSchedule = putCallSchedule_;
 
+         if (!HasAmortizingSchedule())
+         {
+            List<CashFlow> cfs = cashflows();
+
+            arguments.couponDates = new List<Date>(cfs.Count - 1);
+            arguments.couponAmounts = new List<double>(cfs.Count - 1);
+
+            for (int i = 0; i < cfs.Count; i++)
+            {
+               if (!cfs[i].hasOccurred(settlement, false))
+               {
+                  if (cfs[i] is QLNet.FixedRateCoupon)
+                  {
+                     arguments.couponDates.Add(cfs[i].date());
+                     arguments.couponAmounts.Add(cfs[i].amount());
+                  }
+               }
+            }
+
+            for (int i = 0; i < putCallSchedule_.Count; i++)
+            {
+               if (!putCallSchedule_[i].hasOccurred(settlement, false))
+               {
+                  arguments.callabilityDates.Add(putCallSchedule_[i].date());
+                  arguments.callabilityPrices.Add(putCallSchedule_[i].price().amount());
+
+                  if (putCallSchedule_[i].price().type() == Bond.Price.Type.Clean)
+                  {
+                     /* calling accrued() forces accrued interest to be zero
+                        if future option date is also coupon date, so that dirty
+                        price = clean price. Use here because callability is
+                        always applied before coupon in the tree engine.
+                     */
+                     arguments.callabilityPrices[arguments.callabilityPrices.Count - 1] +=
+                        accrued(putCallSchedule_[i].date());
+                  }
+               }
+            }
+
+            return;
+         }
+
+         var deterministicCashflows = AggregateDeterministicCashflows(settlement);
+         arguments.couponDates = deterministicCashflows.Select(item => item.Date).ToList();
+         arguments.couponAmounts = deterministicCashflows.Select(item => item.Amount).ToList();
+
          for (int i = 0; i < putCallSchedule_.Count; i++)
          {
             if (!putCallSchedule_[i].hasOccurred(settlement, false))
             {
                arguments.callabilityDates.Add(putCallSchedule_[i].date());
-               arguments.callabilityPrices.Add(putCallSchedule_[i].price().amount());
-
-               if (putCallSchedule_[i].price().type() == Bond.Price.Type.Clean)
-               {
-                  /* calling accrued() forces accrued interest to be zero
-                     if future option date is also coupon date, so that dirty
-                     price = clean price. Use here because callability is
-                     always applied before coupon in the tree engine.
-                  */
-                  arguments.callabilityPrices[arguments.callabilityPrices.Count - 1] +=
-                     accrued(putCallSchedule_[i].date());
-               }
+               arguments.callabilityPrices.Add(CalculateCallabilityPrice(putCallSchedule_[i]));
             }
          }
       }
@@ -611,8 +631,8 @@ namespace QLNet
          public NpvSpreadHelper(CallableBond bond)
          {
             bond_ = bond;
-            results_ = bond.engine_.getResults() as Instrument.Results;
             bond.setupArguments(bond.engine_.getArguments());
+            results_ = bond.engine_.getResults() as CallableBond.Results;
          }
 
          public double value(double x)
@@ -623,11 +643,18 @@ namespace QLNet
             args.spread = x;
             bond_.engine_.calculate();
             args.spread = originalSpread;
-            return results_.value.Value;
+
+            var currentNotional = bond_.notional(args.settlementDate);
+            if (currentNotional.IsEqual(0.0))
+            {
+               return 0.0;
+            }
+
+            return results_.settlementValue.Value * 100.0 / currentNotional;
          }
 
          private CallableBond bond_;
-         private Instrument.Results results_;
+         private CallableBond.Results results_;
       }
 
       protected class OasHelper : ISolver1d
@@ -796,9 +823,22 @@ namespace QLNet
          if (couponType == CouponType.FixedRate)
          {
             var fixedRateBondSchedule = mainSchedule_.until(maturityDate);
-            var fixedRateBondCoupons = coupons_.Take(mainSchedule_.size() - 1).ToList();
-            var bond = new FixedRateBond(settlementDays_, faceAmount_, fixedRateBondSchedule, fixedRateBondCoupons,
-               paymentDayCounter_, BusinessDayConvention.Unadjusted, redemption, issueDate_);
+            var fixedRateBondCoupons = coupons_.Take(fixedRateBondSchedule.size() - 1).ToList();
+            Bond bond;
+
+            if (HasAmortizingSchedule())
+            {
+               var fixedRateBondNotionals = notionalsByPeriod_.Take(fixedRateBondSchedule.size() - 1).ToList();
+               var redemptionMultipliers = CreateRedemptionMultipliers(fixedRateBondSchedule, fixedRateBondNotionals, redemption);
+               bond = new CallableSupportFixedRateBond(settlementDays_, fixedRateBondSchedule, fixedRateBondCoupons,
+                  fixedRateBondNotionals, paymentDayCounter_, paymentConvention_, issueDate_, redemptionMultipliers);
+            }
+            else
+            {
+               bond = new FixedRateBond(settlementDays_, faceAmount_, fixedRateBondSchedule, fixedRateBondCoupons,
+                  paymentDayCounter_, BusinessDayConvention.Unadjusted, redemption, issueDate_);
+            }
+
             return bond;
          }
          else
@@ -866,7 +906,7 @@ namespace QLNet
             cashflows = new FixedRateLeg(truncatedSchedule)
                .withCouponRates(truncatedCoupons, paymentDayCounter_)
                .withPaymentCalendar(calendar_)
-               .withNotionals(faceAmount_)
+               .withNotionals(HasAmortizingSchedule() ? notionalsByPeriod_.Take(truncatedSchedule.size() - 1).ToList() : [faceAmount_])
                .withPaymentAdjustment(BusinessDayConvention.Unadjusted);
 
             effectiveMaturityDate = truncatedSchedule.endDate();
@@ -877,9 +917,19 @@ namespace QLNet
             cashflows = [];
          }
 
-         // Add redemption cashflow
-         var redemptionAmount = redemption.GetValueOrDefault(100.0) * faceAmount_ / 100.0;
-         cashflows.Add(new SimpleCashFlow(redemptionAmount, effectiveMaturityDate));
+         if (HasAmortizingSchedule())
+         {
+            var redemptionMultipliers = CreateRedemptionMultipliers(
+               mainSchedule_.until(effectiveMaturityDate),
+               notionalsByPeriod_.Take(mainSchedule_.until(effectiveMaturityDate).size() - 1).ToList(),
+               redemption.GetValueOrDefault(100.0));
+            AddPrincipalCashflows(cashflows, redemptionMultipliers);
+         }
+         else
+         {
+            var redemptionAmount = redemption.GetValueOrDefault(100.0) * faceAmount_ / 100.0;
+            cashflows.Add(new SimpleCashFlow(redemptionAmount, effectiveMaturityDate));
+         }
 
          // Determine compounding based on maturity
          var comp = GetCompounding(cashflows, settlementDate, effectiveMaturityDate, couponType);
@@ -901,6 +951,189 @@ namespace QLNet
          public double? CalcPrice { get; set; }
          public double? CalcModifiedDuration { get; set; }
          public string ErrorMessage { get; set; }
+      }
+
+      protected bool HasAmortizingSchedule()
+      {
+         return hasAmortizingSchedule_;
+      }
+
+      protected List<(Date Date, double Amount)> AggregateDeterministicCashflows(Date settlement)
+      {
+         return cashflows_
+            .Where(cashflow => !cashflow.hasOccurred(settlement, false) && cashflow != redemption())
+            .GroupBy(cashflow => cashflow.date())
+            .Select(group => (group.Key, group.Sum(cashflow => cashflow.amount())))
+            .OrderBy(item => item.Key)
+            .ToList();
+      }
+
+      protected double CalculateCallabilityPrice(Callability call)
+      {
+         var callPrice = call.price().amount();
+         if (HasAmortizingSchedule())
+         {
+            callPrice *= GetOutstandingNotionalAtExercise(call.date()) / faceAmount_;
+         }
+
+         if (call.price().type() != Bond.Price.Type.Clean)
+         {
+            return callPrice;
+         }
+
+         if (HasAmortizingSchedule())
+         {
+            return callPrice + GetAccruedAmountAt(call.date()) * 100.0 / faceAmount_;
+         }
+
+         return callPrice + accrued(call.date());
+      }
+
+      protected double GetOutstandingNotionalAtExercise(Date exerciseDate)
+      {
+         if (!HasAmortizingSchedule())
+         {
+            return faceAmount_;
+         }
+
+         for (var i = 0; i < mainSchedule_.Count - 1; i++)
+         {
+            if (exerciseDate <= mainSchedule_[i + 1])
+            {
+               return notionalsByPeriod_[Math.Min(i, notionalsByPeriod_.Count - 1)];
+            }
+         }
+
+         return notionalsByPeriod_.Last();
+      }
+
+      protected double GetAccruedAmountAt(Date settlement)
+      {
+         const bool includeToday = false;
+         for (int i = 0; i < cashflows_.Count; ++i)
+         {
+            if (!cashflows_[i].hasOccurred(settlement, includeToday))
+            {
+               if (cashflows_[i] is Coupon coupon)
+               {
+                  return coupon.accruedAmount(settlement);
+               }
+
+               return 0.0;
+            }
+         }
+
+         return 0.0;
+      }
+
+      protected List<double> CreateRedemptionMultipliers(Schedule schedule, List<double> notionals, double finalRedemption)
+      {
+         var redemptionMultipliers = new List<double> { 100.0 };
+         for (var i = 0; i < schedule.Count - 1; i++)
+         {
+            var currentNotional = notionals[Math.Min(i, notionals.Count - 1)];
+            var nextNotional = i + 1 < notionals.Count ? notionals[i + 1] : 0.0;
+            if (nextNotional < currentNotional)
+            {
+               redemptionMultipliers.Add(i == schedule.Count - 2 ? finalRedemption : 100.0);
+            }
+         }
+
+         return redemptionMultipliers;
+      }
+
+      protected void AddPrincipalCashflows(List<CashFlow> cashflows, List<double> redemptionMultipliers)
+      {
+         var notionals = new List<double>();
+         var notionalSchedule = new List<Date>();
+         Date lastPaymentDate = new Date();
+         notionalSchedule.Add(new Date());
+
+         foreach (var cashflow in cashflows)
+         {
+            if (cashflow is not Coupon coupon)
+            {
+               continue;
+            }
+
+            var notional = coupon.nominal();
+            if (notionals.empty())
+            {
+               notionals.Add(notional);
+               lastPaymentDate = coupon.date();
+            }
+            else if (!Utils.close(notional, notionals.Last()))
+            {
+               notionals.Add(notional);
+               notionalSchedule.Add(lastPaymentDate);
+               lastPaymentDate = coupon.date();
+            }
+            else
+            {
+               lastPaymentDate = coupon.date();
+            }
+         }
+
+         notionals.Add(0.0);
+         notionalSchedule.Add(lastPaymentDate);
+
+         for (int i = 1; i < notionalSchedule.Count; ++i)
+         {
+            var redemptionMultiplier = i < redemptionMultipliers.Count ? redemptionMultipliers[i] : redemptionMultipliers.Last();
+            var amount = (redemptionMultiplier / 100.0) * (notionals[i - 1] - notionals[i]);
+            CashFlow payment = i < notionalSchedule.Count - 1
+               ? new AmortizingPayment(amount, notionalSchedule[i])
+               : new Redemption(amount, notionalSchedule[i]);
+            cashflows.Add(payment);
+         }
+
+         cashflows.Sort((left, right) => left.date().CompareTo(right.date()));
+      }
+
+      protected class CallableSupportFixedRateBond : Bond
+      {
+         public CallableSupportFixedRateBond(
+            int settlementDays,
+            Schedule schedule,
+            List<double> coupons,
+            List<double> notionals,
+            DayCounter accrualDayCounter,
+            BusinessDayConvention paymentConvention,
+            Date issueDate,
+            List<double> redemptionMultipliers)
+            : base(settlementDays, schedule.calendar(), issueDate)
+         {
+            maturityDate_ = schedule.endDate();
+
+            cashflows_ = new FixedRateLeg(schedule)
+               .withCouponRates(coupons, accrualDayCounter)
+               .withNotionals(notionals)
+               .withPaymentAdjustment(paymentConvention)
+               .value();
+
+            calculateNotionalsFromCashflows();
+            AddPrincipalCashflows(redemptionMultipliers);
+         }
+
+         private void AddPrincipalCashflows(List<double> redemptionMultipliers)
+         {
+            for (int i = 1; i < notionalSchedule_.Count; ++i)
+            {
+               var redemptionMultiplier = i < redemptionMultipliers.Count ? redemptionMultipliers[i] : redemptionMultipliers.Last();
+               var amount = (redemptionMultiplier / 100.0) * (notionals_[i - 1] - notionals_[i]);
+               CashFlow payment = i < notionalSchedule_.Count - 1
+                  ? new AmortizingPayment(amount, notionalSchedule_[i])
+                  : new Redemption(amount, notionalSchedule_[i]);
+
+               cashflows_.Add(payment);
+               if (payment is Redemption redemption)
+               {
+                  redemptions_.Add(redemption);
+               }
+            }
+
+            cashflows_ = cashflows_.OrderBy(cashflow => cashflow.date()).ToList();
+         }
       }
    }
 
@@ -925,14 +1158,48 @@ namespace QLNet
       {
          mainSchedule_ = schedule;
          coupons_ = coupons;
+         hasAmortizingSchedule_ = false;
          redemption_ = redemption;
          frequency_ = schedule.tenor().frequency();
+         paymentConvention_ = paymentConvention;
          cashflows_ = new FixedRateLeg(schedule)
-            .withCouponRates(coupons, accrualDayCounter)
-            .withNotionals(faceAmount)
-            .withPaymentAdjustment(paymentConvention);
+           .withCouponRates(coupons, accrualDayCounter)
+           .withNotionals(faceAmount)
+           .withPaymentAdjustment(paymentConvention);
 
          addRedemptionsToCashflows([redemption]);
+      }
+
+      public CallableFixedRateBond(int settlementDays,
+         double faceAmount,
+         Schedule schedule,
+         List<double> coupons,
+         List<double> notionals,
+         DayCounter accrualDayCounter,
+         BusinessDayConvention paymentConvention = BusinessDayConvention.Following,
+         double redemption = 100.0,
+         Date issueDate = null,
+         CallabilitySchedule putCallSchedule = null)
+         : base(settlementDays, schedule.dates().Last(), schedule.calendar(), accrualDayCounter, faceAmount, issueDate,
+           putCallSchedule)
+      {
+         mainSchedule_ = schedule;
+         coupons_ = coupons;
+         notionalsByPeriod_ = notionals;
+         hasAmortizingSchedule_ = notionals is { Count: > 0 };
+         redemption_ = redemption;
+         frequency_ = schedule.tenor().frequency();
+         paymentConvention_ = paymentConvention;
+         cashflows_ = new FixedRateLeg(schedule)
+           .withCouponRates(coupons, accrualDayCounter)
+           .withNotionals(notionals)
+           .withPaymentAdjustment(paymentConvention)
+           .value();
+
+         calculateNotionalsFromCashflows();
+         AddPrincipalCashflows(cashflows_, CreateRedemptionMultipliers(schedule, notionals, redemption));
+         redemptions_.Clear();
+         redemptions_.Add(cashflows_.OfType<Redemption>().Last());
       }
 
       public override CallableCalcs[] yieldToCalls(Date settlement, double price, Frequency frequency,

--- a/src/QLNet/Instruments/Bonds/CallableBond.cs
+++ b/src/QLNet/Instruments/Bonds/CallableBond.cs
@@ -1087,7 +1087,9 @@ namespace QLNet
             cashflows.Add(payment);
          }
 
-         cashflows.Sort((left, right) => left.date().CompareTo(right.date()));
+         var orderedCashflows = cashflows.OrderBy(cashflow => cashflow.date()).ToList();
+         cashflows.Clear();
+         cashflows.AddRange(orderedCashflows);
       }
 
       protected class CallableSupportFixedRateBond : Bond
@@ -1185,8 +1187,9 @@ namespace QLNet
       {
          mainSchedule_ = schedule;
          coupons_ = coupons;
+         Utils.QL_REQUIRE(notionals is { Count: > 0 }, () => "no notionals provided");
          notionalsByPeriod_ = notionals;
-         hasAmortizingSchedule_ = notionals is { Count: > 0 };
+         hasAmortizingSchedule_ = true;
          redemption_ = redemption;
          frequency_ = schedule.tenor().frequency();
          paymentConvention_ = paymentConvention;

--- a/tests/QLNet.Benchmarks/QLNet.Benchmarks.csproj
+++ b/tests/QLNet.Benchmarks/QLNet.Benchmarks.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/tests/QLNet.Tests/QLNet.Tests.csproj
+++ b/tests/QLNet.Tests/QLNet.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0</TargetFrameworks>
+    <TargetFrameworks>net10.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
@@ -13,7 +13,7 @@
   <ItemGroup>
     <PackageReference Include="AutoBogus" Version="2.13.1" />
     <PackageReference Include="coverlet.collector" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0 " />
     <PackageReference Include="xunit" Version="2.9.2" />
     <PackageReference Include="Xunit.Priority" Version="1.1.6" />

--- a/tests/QLNet.Tests/T_CallableBonds.cs
+++ b/tests/QLNet.Tests/T_CallableBonds.cs
@@ -1125,7 +1125,7 @@ public class CallableBondsTests
             .Where(sinkTerm => sinkTerm.SinkDate >= periodEndDate)
             .Sum(sinkTerm => sinkTerm.Amount);
 
-         notionals.Add(faceAmount * outstandingPrincipal / faceAmount);
+         notionals.Add(outstandingPrincipal);
       }
 
       return notionals;

--- a/tests/QLNet.Tests/T_CallableBonds.cs
+++ b/tests/QLNet.Tests/T_CallableBonds.cs
@@ -1004,4 +1004,130 @@ public class CallableBondsTests
          $"    yieldExact    : {yieldExact * 100.0:F6}%\n" +
          $"    error         : {errorBps:F4} bps");
    }
+
+   [Fact]
+   public void testSinkableCallableMatchesReferenceDurations()
+   {
+      var settlementDate = new DateTime(2026, 6, 11);
+      var maturityDate = new DateTime(2052, 7, 1);
+      var firstCallDate = new DateTime(2036, 7, 1);
+      var faceAmount = 39755000.0;
+      const double baseOas = 0.0;
+      const double referenceCleanPrice = 104.582;
+      const double referenceEffectiveDuration = 7.91;
+      const double effectiveDurationTolerance = 0.15;
+      const double referenceOasDuration = 13.94;
+      const double oasDurationTolerance = 0.02;
+
+      Settings.setEvaluationDate(settlementDate);
+
+      var curveDayCounter = new ActualActual(ActualActual.Convention.Bond);
+      var curve = buildReferenceCurve(settlementDate, curveDayCounter);
+      var termStructure = new Handle<YieldTermStructure>(curve);
+      var model = new HullWhite(termStructure, 0.03, 1.0e-12);
+
+      var scheduleStart = maturityDate;
+      while (scheduleStart > settlementDate)
+         scheduleStart = scheduleStart.AddMonths(-6);
+
+      var schedule = new Schedule(
+         scheduleStart,
+         maturityDate,
+         new Period(Frequency.Semiannual),
+         new TARGET(),
+         BusinessDayConvention.Unadjusted,
+         BusinessDayConvention.Unadjusted,
+         DateGeneration.Rule.Backward,
+         false);
+
+      var notionals = buildSinkableNotionals(schedule, faceAmount);
+      var callSchedule = new CallabilitySchedule();
+      for (var callDate = firstCallDate; callDate <= maturityDate; callDate = callDate.AddMonths(6))
+      {
+         callSchedule.Add(new Callability(new Bond.Price(100.0, Bond.Price.Type.Clean), Callability.Type.Call, callDate));
+      }
+
+      var bond = new CallableFixedRateBond(
+         0,
+         faceAmount,
+         schedule,
+         [0.05],
+         notionals,
+         new Thirty360(Thirty360.Thirty360Convention.BondBasis),
+         BusinessDayConvention.Unadjusted,
+         100.0,
+         new Date(),
+         callSchedule);
+
+      bond.setPricingEngine(new TreeCallableFixedRateBondEngine(model, 240, termStructure));
+
+      var effectiveDuration = bond.effectiveDuration(baseOas, termStructure, curveDayCounter, Compounding.Compounded, Frequency.Semiannual);
+      var oas = bond.OAS(referenceCleanPrice, termStructure, curveDayCounter, Compounding.Compounded, Frequency.Semiannual, settlementDate);
+      var oasDuration = bond.effectiveDuration(oas, termStructure, curveDayCounter, Compounding.Compounded, Frequency.Semiannual);
+
+      if (Math.Abs(effectiveDuration - referenceEffectiveDuration) > effectiveDurationTolerance)
+         QAssert.Fail("failed to reproduce sinkable callable effective duration:\n"
+                      + "    calculated: " + effectiveDuration + "\n"
+                      + "    expected:   " + referenceEffectiveDuration + " +/- " + effectiveDurationTolerance);
+
+      if (Math.Abs(oasDuration - referenceOasDuration) > oasDurationTolerance)
+         QAssert.Fail("failed to reproduce sinkable callable OAS duration:\n"
+                      + "    calculated: " + oasDuration + "\n"
+                      + "    expected:   " + referenceOasDuration + " +/- " + oasDurationTolerance);
+   }
+
+   private static InterpolatedZeroCurve<Linear> buildReferenceCurve(DateTime settlementDate, DayCounter dayCounter)
+   {
+      var dates = new List<Date>
+      {
+         new Date(settlementDate),
+         new Date(settlementDate.AddMonths(3)),
+         new Date(settlementDate.AddMonths(6)),
+      };
+
+      var rates = new List<double>
+      {
+         0.0253,
+         0.0253,
+         0.0239,
+      };
+
+      var parCurveRates = new[]
+      {
+         2.38, 2.40, 2.42, 2.50, 2.56, 2.64, 2.72, 2.77, 2.86, 2.95,
+         3.04, 3.12, 3.19, 3.22, 3.26, 3.36, 3.46, 3.59, 3.73, 3.85,
+         3.93, 4.00, 4.05, 4.11, 4.13, 4.16, 4.17, 4.20, 4.21, 4.23
+      };
+
+      for (var year = 1; year <= parCurveRates.Length; year++)
+      {
+         dates.Add(new Date(settlementDate.AddYears(year)));
+         rates.Add(parCurveRates[year - 1] / 100.0);
+      }
+
+      return new InterpolatedZeroCurve<Linear>(dates, rates, dayCounter);
+   }
+
+   private static List<double> buildSinkableNotionals(Schedule schedule, double faceAmount)
+   {
+      var sinkTerms = new List<(DateTime SinkDate, double Amount)>
+      {
+         (new DateTime(2050, 7, 1), 11905000.0),
+         (new DateTime(2051, 7, 1), 12505000.0),
+         (new DateTime(2052, 7, 1), 14145000.0),
+      };
+
+      var notionals = new List<double>(schedule.Count - 1);
+      for (var periodIndex = 0; periodIndex < schedule.Count - 1; periodIndex++)
+      {
+         var periodEndDate = DateTime.SpecifyKind(schedule[periodIndex + 1], DateTimeKind.Utc);
+         var outstandingPrincipal = sinkTerms
+            .Where(sinkTerm => sinkTerm.SinkDate >= periodEndDate)
+            .Sum(sinkTerm => sinkTerm.Amount);
+
+         notionals.Add(faceAmount * outstandingPrincipal / faceAmount);
+      }
+
+      return notionals;
+   }
 }


### PR DESCRIPTION
This pull request introduces significant enhancements to the `CallableBond` implementation, primarily to support amortizing bonds and improve callability and cashflow calculations. Additionally, it updates the test and benchmark projects to .NET 10 and upgrades a test dependency.

### CallableBond amortization and cashflow improvements

* Added support for amortizing callable bonds by introducing new fields (`notionalsByPeriod_`, `hasAmortizingSchedule_`, `paymentConvention_`) and logic to handle amortizing schedules, notional tracking, and principal payments. This includes new constructors and helper methods such as `HasAmortizingSchedule`, `AggregateDeterministicCashflows`, `CreateRedemptionMultipliers`, and `AddPrincipalCashflows`. [[1]](diffhunk://#diff-7ba69619400cd43048a6f0475c4757ebfa9f7572be48a45ac24e66640b2550f8R45-R47) [[2]](diffhunk://#diff-7ba69619400cd43048a6f0475c4757ebfa9f7572be48a45ac24e66640b2550f8R1161-R1164) [[3]](diffhunk://#diff-7ba69619400cd43048a6f0475c4757ebfa9f7572be48a45ac24e66640b2550f8R1173-R1204) [[4]](diffhunk://#diff-7ba69619400cd43048a6f0475c4757ebfa9f7572be48a45ac24e66640b2550f8L869-R909) [[5]](diffhunk://#diff-7ba69619400cd43048a6f0475c4757ebfa9f7572be48a45ac24e66640b2550f8L880-R932) [[6]](diffhunk://#diff-7ba69619400cd43048a6f0475c4757ebfa9f7572be48a45ac24e66640b2550f8R955-R1137)
* Refactored the `setupArguments` method to handle both standard and amortizing callable bonds, ensuring correct cashflow and callability date/price calculation for each case. [[1]](diffhunk://#diff-7ba69619400cd43048a6f0475c4757ebfa9f7572be48a45ac24e66640b2550f8R130-R137) [[2]](diffhunk://#diff-7ba69619400cd43048a6f0475c4757ebfa9f7572be48a45ac24e66640b2550f8L145-L150) [[3]](diffhunk://#diff-7ba69619400cd43048a6f0475c4757ebfa9f7572be48a45ac24e66640b2550f8R174-R189)

### Pricing and calculation logic

* Improved calculation of callability prices and notional amounts at call dates, especially for amortizing bonds, by adding methods like `CalculateCallabilityPrice`, `GetOutstandingNotionalAtExercise`, and `GetAccruedAmountAt`.
* Updated the `NpvSpreadHelper` to use the correct results type and properly scale settlement value by the outstanding notional, returning zero for fully redeemed bonds. [[1]](diffhunk://#diff-7ba69619400cd43048a6f0475c4757ebfa9f7572be48a45ac24e66640b2550f8L614-R635) [[2]](diffhunk://#diff-7ba69619400cd43048a6f0475c4757ebfa9f7572be48a45ac24e66640b2550f8L626-R657)

### Project and dependency updates

* Updated test and benchmark projects to target .NET 10 for improved compatibility and performance. [[1]](diffhunk://#diff-bec3101f8994df5cd51bb36b839b6d34066f1c9679bac7a87fc06050844db94eL5-R5) [[2]](diffhunk://#diff-987882c29f8ac150e61a5bf7be2401846e1015065c7875ea9901886bb75d8914L4-R4)
* Upgraded `Microsoft.Extensions.Logging.Abstractions` dependency in tests to version 10.0.0.