### PR TITLE
Fix 30/360 US, 30/365 and Act/365 Canadian day counters diverging from QuantLib

### DIFF
--- a/src/QLNet/Time/DayCounters/Actual365Fixed.cs
+++ b/src/QLNet/Time/DayCounters/Actual365Fixed.cs
@@ -72,6 +72,7 @@ namespace QLNet
             var months = (int)(Math.Round(12 * dcc / 365));
             Utils.QL_REQUIRE(months != 0, ()=> "invalid reference period for Act/365 Canadian; must be longer than a month");
             var frequency = (int)(12 / months);
+            Utils.QL_REQUIRE(frequency != 0, ()=> "invalid reference period for Act/365 Canadian; must not be longer than a year");
 
             if (dcs < (int)(365/frequency))
                return dcs/365.0;

--- a/src/QLNet/Time/DayCounters/Thirty360.cs
+++ b/src/QLNet/Time/DayCounters/Thirty360.cs
@@ -110,11 +110,15 @@ namespace QLNet
             int mm1 = d1.Month, mm2 = d2.Month;
             int yy1 = d1.Year, yy2 = d2.Year;
 
-            if (dd1 == 31) { dd1 = 30; }
+            // See https://en.wikipedia.org/wiki/Day_count_convention#30/360_US
+            // NOTE: the order of checks is important
+            if (IsLastOfFebruary(dd1, mm1, yy1))
+            {
+               if (IsLastOfFebruary(dd2, mm2, yy2)) { dd2 = 30; }
+               dd1 = 30;
+            }
             if (dd2 == 31 && dd1 >= 30) { dd2 = 30; }
-
-            if (IsLastOfFebruary(dd2, mm2, yy2) && IsLastOfFebruary(dd1, mm1, yy1)) { dd2 = 30; }
-            if (IsLastOfFebruary(dd1, mm1, yy1)) { dd1 = 30; }
+            if (dd1 == 31) { dd1 = 30; }
 
             return 360*(yy2-yy1) + 30*(mm2-mm1) + (dd2-dd1);
          }

--- a/src/QLNet/Time/DayCounters/Thirty365.cs
+++ b/src/QLNet/Time/DayCounters/Thirty365.cs
@@ -37,6 +37,10 @@ namespace QLNet
             int mm1 = d1.month(), mm2 = d2.month();
             int yy1 = d1.year(), yy2 = d2.year();
 
+            // date adjustment rules as in ISO 20022
+            if (dd1 == 31) { dd1 = 30; }
+            if (dd2 == 31) { dd2 = 30; }
+
             return 360*(yy2-yy1) + 30*(mm2-mm1) + (dd2-dd1);
          }
 

--- a/tests/QLNet.Tests/T_DayCounters.cs
+++ b/tests/QLNet.Tests/T_DayCounters.cs
@@ -652,6 +652,31 @@ namespace QLNet.Tests
                          + "    calculated: " + t + "\n"
                          + "    expected:   " + expected);
          }
+
+         // Endpoints falling on the 31st, which the case above does not exercise.
+         // The 31 -> 30 adjustment is the one prescribed by ISO 20022.
+         Thirty360Case[] data =
+         {
+            new Thirty360Case(new Date(31, Month.January, 2007),  new Date(1, Month.February, 2007),     1),
+            new Thirty360Case(new Date(31, Month.December, 2007), new Date(1, Month.January, 2008),      1),
+            new Thirty360Case(new Date(1, Month.January, 2007),   new Date(31, Month.January, 2007),    29),
+            new Thirty360Case(new Date(31, Month.January, 2007),  new Date(28, Month.February, 2007),   28),
+            new Thirty360Case(new Date(31, Month.January, 2007),  new Date(31, Month.March, 2007),      60),
+            new Thirty360Case(new Date(31, Month.December, 2006), new Date(31, Month.December, 2007),  360),
+            new Thirty360Case(new Date(29, Month.February, 2008), new Date(31, Month.March, 2008),      31)
+         };
+
+         foreach (var x in data)
+         {
+            var calculated = dayCounter.dayCount(x._start, x._end);
+            if (calculated != x._expected)
+            {
+               QAssert.Fail("from " + x._start
+                         + " to " + x._end + ":\n"
+                         + "    calculated: " + calculated + "\n"
+                         + "    expected:   " + x._expected);
+            }
+         }
       }
 
       [Fact]
@@ -891,6 +916,108 @@ namespace QLNet.Tests
                          + "    expected:   " + x._expected);
             }
          }
+      }
+
+      [Fact]
+      public void testThirty360_USA()
+      {
+         // Testing thirty/360 day counter (US)
+         // Source: SIA "Standard Securities Calculation Methods", as summarised at
+         // https://en.wikipedia.org/wiki/Day_count_convention#30/360_US
+
+         DayCounter dayCounter = new Thirty360(Thirty360.Thirty360Convention.USA);
+
+         Thirty360Case[] data =
+         {
+            // start date is the last day of February: it becomes the 30th, which in turn
+            // lets an end date on the 31st be pulled back to the 30th
+            new Thirty360Case(new Date(28, Month.February, 2007), new Date(31, Month.March, 2007),      30),
+            new Thirty360Case(new Date(28, Month.February, 2007), new Date(31, Month.May, 2007),        90),
+            new Thirty360Case(new Date(28, Month.February, 2007), new Date(31, Month.August, 2007),    180),
+            new Thirty360Case(new Date(29, Month.February, 2008), new Date(31, Month.August, 2008),    180),
+            // both dates are the last day of February
+            new Thirty360Case(new Date(28, Month.February, 2007), new Date(28, Month.February, 2008),  358),
+            new Thirty360Case(new Date(28, Month.February, 2007), new Date(29, Month.February, 2008),  360),
+            new Thirty360Case(new Date(29, Month.February, 2008), new Date(28, Month.February, 2009),  360),
+            // start date is the last day of February, end date is not the 31st
+            new Thirty360Case(new Date(28, Month.February, 2007), new Date(1, Month.March, 2007),        1),
+            new Thirty360Case(new Date(29, Month.February, 2008), new Date(1, Month.March, 2008),        1),
+            // start date is in February but not its last day: the end date keeps its 31
+            new Thirty360Case(new Date(15, Month.February, 2007), new Date(31, Month.March, 2007),      46),
+            new Thirty360Case(new Date(28, Month.February, 2008), new Date(31, Month.August, 2008),    183),
+            // no February involved
+            new Thirty360Case(new Date(30, Month.January, 2007),  new Date(31, Month.March, 2007),      60),
+            new Thirty360Case(new Date(31, Month.January, 2007),  new Date(31, Month.March, 2007),      60),
+            new Thirty360Case(new Date(20, Month.August, 2006),   new Date(20, Month.February, 2007),  180),
+            new Thirty360Case(new Date(31, Month.August, 2007),   new Date(28, Month.February, 2008),  178),
+            new Thirty360Case(new Date(30, Month.September, 2006), new Date(31, Month.October, 2006),   30),
+            new Thirty360Case(new Date(31, Month.October, 2006),  new Date(28, Month.November, 2006),   28),
+            new Thirty360Case(new Date(30, Month.November, 2007), new Date(31, Month.December, 2007),   30),
+            new Thirty360Case(new Date(31, Month.December, 2007), new Date(31, Month.January, 2008),    30)
+         };
+
+         foreach (var x in data)
+         {
+            var calculated = dayCounter.dayCount(x._start, x._end);
+            if (calculated != x._expected)
+            {
+               QAssert.Fail("from " + x._start
+                         + " to " + x._end + ":\n"
+                         + "    calculated: " + calculated + "\n"
+                         + "    expected:   " + x._expected);
+            }
+         }
+      }
+
+      [Fact]
+      public void testThirty360_NASD()
+      {
+         // Testing thirty/360 day counter (NASD)
+
+         DayCounter dayCounter = new Thirty360(Thirty360.Thirty360Convention.NASD);
+
+         Thirty360Case[] data =
+         {
+            // end date on the 31st with a start date before the 30th rolls to the 1st
+            // of the next month, so February is not treated specially here
+            new Thirty360Case(new Date(28, Month.February, 2007), new Date(31, Month.March, 2007),      33),
+            new Thirty360Case(new Date(15, Month.February, 2007), new Date(31, Month.March, 2007),      46),
+            new Thirty360Case(new Date(29, Month.February, 2008), new Date(31, Month.August, 2008),    182),
+            new Thirty360Case(new Date(1, Month.January, 2007),   new Date(31, Month.January, 2007),    30),
+            new Thirty360Case(new Date(15, Month.June, 2007),     new Date(31, Month.December, 2007),  196),
+            // start date on the 30th or 31st pulls the end date back to the 30th instead
+            new Thirty360Case(new Date(30, Month.January, 2007),  new Date(31, Month.March, 2007),      60),
+            new Thirty360Case(new Date(31, Month.January, 2007),  new Date(31, Month.March, 2007),      60),
+            new Thirty360Case(new Date(20, Month.August, 2006),   new Date(20, Month.February, 2007),  180),
+            new Thirty360Case(new Date(31, Month.August, 2007),   new Date(28, Month.February, 2008),  178)
+         };
+
+         foreach (var x in data)
+         {
+            var calculated = dayCounter.dayCount(x._start, x._end);
+            if (calculated != x._expected)
+            {
+               QAssert.Fail("from " + x._start
+                         + " to " + x._end + ":\n"
+                         + "    calculated: " + calculated + "\n"
+                         + "    expected:   " + x._expected);
+            }
+         }
+      }
+
+      [Fact]
+      public void testActual365_CanadianLongReferencePeriod()
+      {
+         // Testing that Actual/365 (Canadian) rejects a reference period longer than a year
+         // instead of dividing by a zero frequency
+
+         var dayCounter = new Actual365Fixed(Actual365Fixed.Convention.Canadian);
+
+         Assert.Throws<ArgumentException>(() =>
+            dayCounter.yearFraction(new Date(1, Month.January, 2007),
+                                    new Date(1, Month.July, 2007),
+                                    new Date(1, Month.January, 2007),
+                                    new Date(1, Month.January, 2009)));
       }
 
       [Fact]


### PR DESCRIPTION
Three day counters return different values from the QuantLib functions they port. Numbers below are from QuantLib 1.43 against QLNet `develop`.

| case | QLNet | QuantLib 1.43 |
|---|---|---|
| `Thirty360(USA).dayCount(2007-02-28, 2007-03-31)` | 31 | 30 |
| `Thirty360(USA).dayCount(2008-02-29, 2008-08-31)` | 181 | 180 |
| `Thirty365().dayCount(2007-01-31, 2007-02-01)` | 0 | 1 |
| `Thirty365().dayCount(2007-01-01, 2007-01-31)` | 30 | 29 |
| `Actual365Fixed(Canadian)`, 2-year reference period | `DivideByZeroException` | domain error |

`UsImpl` runs the last-of-February adjustments after the `31 -> 30` checks, so D1 is still 28/29 when `dd2 == 31 && dd1 >= 30` is tested and D2 never collapses to 30. `thirty360.cpp` `US_Impl::dayCount` puts the February block first, under the comment `// NOTE: the order of checks is important`, and the class docstring here already describes that behaviour. `Thirty365` is missing the two ISO 20022 `31 -> 30` adjustments that `thirty365.cpp` applies, which is why a one-day interval can accrue zero. `CA_Impl` is missing `QL_REQUIRE(frequency != 0, ...)` from `actual365fixed.cpp`.

I compared every counter in `Time/DayCounters` against QuantLib 1.43 over 48,205 date pairs each (month ends, 31sts, Feb 28/29, leap and non-leap years). Only these three diverged: Bond Basis/ISMA, European/Eurobond, Italian, ISDA/German with and without a termination date, NASD, Act/360, Act/364, Act/366, Act/365.25, Act/365F Standard and NoLeap, Act/Act ISDA/AFB/ISMA, Simple, 1/1 and Business/252 all matched already, and all 27 match now.

Adds `testThirty360_USA` and `testThirty360_NASD` (NASD was already correct, just untested), extends `testThirty365` with 31st endpoints, and adds the Canadian guard case. Expected values are QuantLib output. Suite: 533 passed, 0 failed.
