### PR TITLE
[GH-325] Add WeakEventSource.SuppressNotifications() opt-in suppression scope

### DIFF
--- a/src/QLNet/Patterns/WeakEventSource.cs
+++ b/src/QLNet/Patterns/WeakEventSource.cs
@@ -45,7 +45,6 @@ namespace QLNet
 
       public static IDisposable SuppressNotifications()
       {
-         _suppressionDepth++;
          return new SuppressionScope(Environment.CurrentManagedThreadId);
       }
 
@@ -57,6 +56,11 @@ namespace QLNet
          public SuppressionScope(int creatingThreadId)
          {
             _creatingThreadId = creatingThreadId;
+            // Increment only once construction is actually underway, not before allocating this object: if
+            // allocation/construction itself were to throw (e.g. OutOfMemoryException), the counter would
+            // otherwise have already been bumped with no scope ever handed back to the caller to dispose it,
+            // permanently (for this thread) suppressing notifications.
+            _suppressionDepth++;
          }
 
          public void Dispose()
@@ -72,6 +76,13 @@ namespace QLNet
             if (Environment.CurrentManagedThreadId != _creatingThreadId)
                throw new InvalidOperationException(
                   "WeakEventSource.SuppressNotifications() scope must be disposed on the same thread that created it.");
+
+            // Guard against underflow: if _suppressionDepth were ever corrupted (e.g. a misbalanced/duplicated
+            // scope elsewhere), decrementing past 0 would silently leave suppression permanently disabled
+            // (NotificationsSuppressed only checks > 0) instead of failing fast.
+            if (_suppressionDepth <= 0)
+               throw new InvalidOperationException(
+                  "WeakEventSource.SuppressNotifications() scope disposed more times than it was entered on this thread.");
 
             _disposed = true;
             _suppressionDepth--;

--- a/src/QLNet/Patterns/WeakEventSource.cs
+++ b/src/QLNet/Patterns/WeakEventSource.cs
@@ -32,30 +32,38 @@ namespace QLNet
    {
       private readonly List<WeakDelegate> _handlers;
 
-      // Per-thread opt-out for the whole Subscribe/Unsubscribe/Raise pipeline. Some callers construct large
+      // Per-thread opt-out for the Subscribe/Unsubscribe/Raise pipeline. Some callers construct large
       // numbers of short-lived, single-use IObservable/IObserver graphs (e.g. one-off bond pricing) where the
       // observer-notification machinery (reflection-based weak-delegate wrapping, list mutation under lock) is
       // pure overhead: nothing outlives the call, and nothing needs to be notified of anything. Wrapping such a
-      // call in a using(WeakEventSource.SuppressNotifications()) scope makes every WeakEventSource instance a
-      // complete no-op for that thread only, for the scope's lifetime, with no effect on other threads.
+      // call in a using(WeakEventSource.SuppressNotifications()) scope makes Subscribe/Unsubscribe/Raise no-ops
+      // on every WeakEventSource instance, for that thread only, for the scope's lifetime, with no effect on
+      // other threads. Clear() is intentionally NOT suppressed: it discards handlers rather than notifying them,
+      // so it remains active (and still affects the shared handler list for all threads) even inside the scope.
       [ThreadStatic]
       private static int _suppressionDepth;
 
       public static bool NotificationsSuppressed => _suppressionDepth > 0;
 
-      public static IDisposable SuppressNotifications()
+      public static SuppressionScope SuppressNotifications()
       {
          return new SuppressionScope(Environment.CurrentManagedThreadId);
       }
 
-      private sealed class SuppressionScope : IDisposable
+      // Public, non-allocating value-type scope: SuppressNotifications() is meant to be used in hot paths, so
+      // it returns this concrete struct (rather than IDisposable) to let `using (WeakEventSource.
+      // SuppressNotifications())` dispose it via the C# pattern-based using support with no heap allocation and
+      // no boxing. It cannot be a `readonly struct` because Dispose() needs to mutate the _disposed field to
+      // stay idempotent (safe to call more than once), per the usual IDisposable contract.
+      public struct SuppressionScope : IDisposable
       {
          private readonly int _creatingThreadId;
          private bool _disposed;
 
-         public SuppressionScope(int creatingThreadId)
+         internal SuppressionScope(int creatingThreadId)
          {
             _creatingThreadId = creatingThreadId;
+            _disposed = false;
             // Increment only once construction is actually underway, not before allocating this object: if
             // allocation/construction itself were to throw (e.g. OutOfMemoryException), the counter would
             // otherwise have already been bumped with no scope ever handed back to the caller to dispose it,
@@ -134,6 +142,9 @@ namespace QLNet
          }
       }
 
+      // Clear() is intentionally left unaffected by SuppressNotifications(): it discards existing handlers
+      // rather than notifying/adding/removing them, so suppressing it would not save any of the overhead the
+      // scope targets and would instead risk silently keeping stale handlers alive.
       public void Clear()
       {
          lock (_handlers)

--- a/src/QLNet/Patterns/WeakEventSource.cs
+++ b/src/QLNet/Patterns/WeakEventSource.cs
@@ -47,27 +47,36 @@ namespace QLNet
 
       public static SuppressionScope SuppressNotifications()
       {
-         return new SuppressionScope(Environment.CurrentManagedThreadId);
+         return new SuppressionScope(true);
       }
 
-      // Public, non-allocating value-type scope: SuppressNotifications() is meant to be used in hot paths, so
-      // it returns this concrete struct (rather than IDisposable) to let `using (WeakEventSource.
+      // Public, non-allocating, stack-only scope: SuppressNotifications() is meant to be used in hot paths, so
+      // it returns this concrete `ref struct` (rather than IDisposable) to let `using (WeakEventSource.
       // SuppressNotifications())` dispose it via the C# pattern-based using support with no heap allocation and
-      // no boxing. It cannot be a `readonly struct` because Dispose() needs to mutate the _disposed field to
-      // stay idempotent (safe to call more than once), per the usual IDisposable contract.
-      public struct SuppressionScope : IDisposable
+      // no boxing. Being a `ref struct` also means the compiler forbids storing it in a field, capturing it in
+      // a lambda/closure, or using it across an `await`: it simply cannot leave the stack frame/thread that
+      // created it, so it can never be disposed on a different thread than the one that created it (unlike a
+      // normal class/struct, this is enforced at compile time, not by a runtime check). It cannot be a
+      // `readonly struct` because Dispose() needs to mutate the _disposed field to stay idempotent (safe to
+      // call more than once) for the *same* scope instance - a deliberate design choice for this API, not a
+      // requirement of IDisposable itself; note that, as
+      // with any mutable struct, explicitly copying a scope (e.g. `var copy = scope;`) and disposing both is a
+      // caller misuse this type does not protect against - the intended (and only realistic, given it cannot
+      // escape the method) usage is the `using (WeakEventSource.SuppressNotifications())` pattern.
+      public ref struct SuppressionScope
       {
-         private readonly int _creatingThreadId;
          private bool _disposed;
 
-         internal SuppressionScope(int creatingThreadId)
+         // The increment lives in this constructor (rather than in SuppressNotifications() before the
+         // struct value is created) so that it is only ever paired with an actual, real scope instance
+         // being handed back to the caller - i.e. every increment has exactly one corresponding scope
+         // whose Dispose() will decrement it. The unused parameter only exists to disambiguate this
+         // constructor from the compiler-provided public parameterless struct constructor (which must
+         // remain a trivial default and must not bump the counter, since callers can invoke it directly
+         // via `default(SuppressionScope)`).
+         internal SuppressionScope(bool _)
          {
-            _creatingThreadId = creatingThreadId;
             _disposed = false;
-            // Increment only once construction is actually underway, not before allocating this object: if
-            // allocation/construction itself were to throw (e.g. OutOfMemoryException), the counter would
-            // otherwise have already been bumped with no scope ever handed back to the caller to dispose it,
-            // permanently (for this thread) suppressing notifications.
             _suppressionDepth++;
          }
 
@@ -75,15 +84,6 @@ namespace QLNet
          {
             if (_disposed)
                return;
-
-            // _suppressionDepth is [ThreadStatic]: disposing this scope on a thread other than the one that
-            // created it (e.g. after an `await` resumes on a different thread pool thread, or the scope is
-            // otherwise handed off across threads) would decrement the *wrong* thread's counter, silently
-            // corrupting suppression state and potentially leaving the creating thread permanently suppressed.
-            // Fail loudly instead so the misuse is caught immediately.
-            if (Environment.CurrentManagedThreadId != _creatingThreadId)
-               throw new InvalidOperationException(
-                  "WeakEventSource.SuppressNotifications() scope must be disposed on the same thread that created it.");
 
             // Guard against underflow: if _suppressionDepth were ever corrupted (e.g. a misbalanced/duplicated
             // scope elsewhere), decrementing past 0 would silently leave suppression permanently disabled

--- a/src/QLNet/Patterns/WeakEventSource.cs
+++ b/src/QLNet/Patterns/WeakEventSource.cs
@@ -46,17 +46,33 @@ namespace QLNet
       public static IDisposable SuppressNotifications()
       {
          _suppressionDepth++;
-         return new SuppressionScope();
+         return new SuppressionScope(Environment.CurrentManagedThreadId);
       }
 
       private sealed class SuppressionScope : IDisposable
       {
+         private readonly int _creatingThreadId;
          private bool _disposed;
+
+         public SuppressionScope(int creatingThreadId)
+         {
+            _creatingThreadId = creatingThreadId;
+         }
 
          public void Dispose()
          {
             if (_disposed)
                return;
+
+            // _suppressionDepth is [ThreadStatic]: disposing this scope on a thread other than the one that
+            // created it (e.g. after an `await` resumes on a different thread pool thread, or the scope is
+            // otherwise handed off across threads) would decrement the *wrong* thread's counter, silently
+            // corrupting suppression state and potentially leaving the creating thread permanently suppressed.
+            // Fail loudly instead so the misuse is caught immediately.
+            if (Environment.CurrentManagedThreadId != _creatingThreadId)
+               throw new InvalidOperationException(
+                  "WeakEventSource.SuppressNotifications() scope must be disposed on the same thread that created it.");
+
             _disposed = true;
             _suppressionDepth--;
          }

--- a/src/QLNet/Patterns/WeakEventSource.cs
+++ b/src/QLNet/Patterns/WeakEventSource.cs
@@ -57,7 +57,7 @@ namespace QLNet
       // a lambda/closure, or using it across an `await`: it simply cannot leave the stack frame/thread that
       // created it, so it can never be disposed on a different thread than the one that created it (unlike a
       // normal class/struct, this is enforced at compile time, not by a runtime check). It cannot be a
-      // `readonly struct` because Dispose() needs to mutate the _disposed field to stay idempotent (safe to
+      // `readonly struct` because Dispose() needs to mutate the _active field to stay idempotent (safe to
       // call more than once) for the *same* scope instance - a deliberate design choice for this API, not a
       // requirement of IDisposable itself; note that, as
       // with any mutable struct, explicitly copying a scope (e.g. `var copy = scope;`) and disposing both is a
@@ -65,7 +65,15 @@ namespace QLNet
       // escape the method) usage is the `using (WeakEventSource.SuppressNotifications())` pattern.
       public ref struct SuppressionScope
       {
-         private bool _disposed;
+         // Tracks whether this specific scope instance has actually entered a suppression (i.e. was
+         // constructed via SuppressNotifications() and therefore incremented _suppressionDepth), as
+         // opposed to being disposed. This is named/oriented so that `false` is the default bool value:
+         // default(SuppressionScope) (which callers can construct directly, bypassing SuppressNotifications())
+         // is therefore inactive out of the box, and disposing it is a safe no-op that never touches
+         // _suppressionDepth - unlike a "_disposed" flag, whose default (false) would be indistinguishable
+         // from a real, entered-but-not-yet-disposed scope and would let default(SuppressionScope).Dispose()
+         // incorrectly decrement _suppressionDepth for a scope that never incremented it.
+         private bool _active;
 
          // The increment lives in this constructor (rather than in SuppressNotifications() before the
          // struct value is created) so that it is only ever paired with an actual, real scope instance
@@ -76,13 +84,13 @@ namespace QLNet
          // via `default(SuppressionScope)`).
          internal SuppressionScope(bool _)
          {
-            _disposed = false;
+            _active = true;
             _suppressionDepth++;
          }
 
          public void Dispose()
          {
-            if (_disposed)
+            if (!_active)
                return;
 
             // Guard against underflow: if _suppressionDepth were ever corrupted (e.g. a misbalanced/duplicated
@@ -92,7 +100,7 @@ namespace QLNet
                throw new InvalidOperationException(
                   "WeakEventSource.SuppressNotifications() scope disposed more times than it was entered on this thread.");
 
-            _disposed = true;
+            _active = false;
             _suppressionDepth--;
          }
       }

--- a/src/QLNet/Patterns/WeakEventSource.cs
+++ b/src/QLNet/Patterns/WeakEventSource.cs
@@ -1,6 +1,7 @@
 ﻿/*
  Copyright (C) 2016 Thomas Levesque // http://www.thomaslevesque.com/2015/08/16/weak-events-in-c-take-two
  Copyright (C) 2016 Francois Botha (igitur@gmail.com)
+ Copyright (C) 2008-2026  Andrea Maggiulli (a.maggiulli@gmail.com)
 
  This file is part of QLNet Project https://github.com/amaggiulli/qlnet
 
@@ -31,6 +32,36 @@ namespace QLNet
    {
       private readonly List<WeakDelegate> _handlers;
 
+      // Per-thread opt-out for the whole Subscribe/Unsubscribe/Raise pipeline. Some callers construct large
+      // numbers of short-lived, single-use IObservable/IObserver graphs (e.g. one-off bond pricing) where the
+      // observer-notification machinery (reflection-based weak-delegate wrapping, list mutation under lock) is
+      // pure overhead: nothing outlives the call, and nothing needs to be notified of anything. Wrapping such a
+      // call in a using(WeakEventSource.SuppressNotifications()) scope makes every WeakEventSource instance a
+      // complete no-op for that thread only, for the scope's lifetime, with no effect on other threads.
+      [ThreadStatic]
+      private static int _suppressionDepth;
+
+      public static bool NotificationsSuppressed => _suppressionDepth > 0;
+
+      public static IDisposable SuppressNotifications()
+      {
+         _suppressionDepth++;
+         return new SuppressionScope();
+      }
+
+      private sealed class SuppressionScope : IDisposable
+      {
+         private bool _disposed;
+
+         public void Dispose()
+         {
+            if (_disposed)
+               return;
+            _disposed = true;
+            _suppressionDepth--;
+         }
+      }
+
       public WeakEventSource()
       {
          _handlers = new List<WeakDelegate>();
@@ -38,6 +69,9 @@ namespace QLNet
 
       public void Raise()
       {
+         if (NotificationsSuppressed)
+            return;
+
          lock (_handlers)
          {
             _handlers.RemoveAll(h => !h.Invoke());
@@ -46,6 +80,9 @@ namespace QLNet
 
       public void Subscribe(Callback handler)
       {
+         if (NotificationsSuppressed)
+            return;
+
          var weakHandlers = handler
                             .GetInvocationList()
                             .Select(d => new WeakDelegate(d))
@@ -59,6 +96,9 @@ namespace QLNet
 
       public void Unsubscribe(Callback handler)
       {
+         if (NotificationsSuppressed)
+            return;
+
          lock (_handlers)
          {
             int index = _handlers.FindIndex(h => h.IsMatch(handler));

--- a/tests/QLNet.Tests/T_WeakEventSourceSuppression.cs
+++ b/tests/QLNet.Tests/T_WeakEventSourceSuppression.cs
@@ -99,9 +99,10 @@ namespace TestSuite
          scope.Dispose();
          Assert.False(WeakEventSource.NotificationsSuppressed);
 
-         // A second Dispose() call must be a safe no-op (standard IDisposable contract), and must
-         // not decrement _suppressionDepth a second time (which would trigger the underflow guard
-         // on a subsequent, unrelated SuppressNotifications()/Dispose() pair on this thread).
+         // A second Dispose() call must be a safe no-op: this API is explicitly designed to be
+         // idempotent (IDisposable itself doesn't require this, it's just a common convention), and
+         // must not decrement _suppressionDepth a second time (which would trigger the underflow
+         // guard on a subsequent, unrelated SuppressNotifications()/Dispose() pair on this thread).
          scope.Dispose();
          Assert.False(WeakEventSource.NotificationsSuppressed);
 
@@ -112,6 +113,10 @@ namespace TestSuite
 
          Assert.False(WeakEventSource.NotificationsSuppressed);
       }
+
+      // Bounded so that a real deadlock/logic bug in the suppression scope fails the test quickly
+      // with a clear assertion instead of hanging the whole suite indefinitely.
+      private static readonly TimeSpan WaitTimeout = TimeSpan.FromSeconds(10);
 
       [Fact]
       public void SuppressNotifications_IsThreadLocal_OtherThreadsAreUnaffected()
@@ -130,7 +135,7 @@ namespace TestSuite
             {
                // Wait until the main thread has entered its suppression scope before raising, so
                // this genuinely exercises "another thread while suppression is active elsewhere".
-               suppressionEntered.Wait();
+               Assert.True(suppressionEntered.Wait(WaitTimeout));
                Assert.False(WeakEventSource.NotificationsSuppressed);
                source.Raise();
             }
@@ -150,44 +155,20 @@ namespace TestSuite
          {
             Assert.True(WeakEventSource.NotificationsSuppressed);
             suppressionEntered.Set();
-            releaseOtherThread.Wait();
+            Assert.True(releaseOtherThread.Wait(WaitTimeout));
          }
 
-         otherThread.Join();
+         Assert.True(otherThread.Join(WaitTimeout));
 
          Assert.Null(otherThreadException);
          // The other thread was never suppressed, so its Raise() must have invoked the handler.
          Assert.Equal(1, counter.Count);
       }
 
-      [Fact]
-      public void SuppressNotifications_DisposingOnADifferentThreadThrows()
-      {
-         var scope = WeakEventSource.SuppressNotifications();
-         Exception otherThreadException = null;
-
-         var otherThread = new Thread(() =>
-         {
-            try
-            {
-               scope.Dispose();
-            }
-            catch (Exception ex)
-            {
-               otherThreadException = ex;
-            }
-         });
-         otherThread.IsBackground = true;
-         otherThread.Start();
-         otherThread.Join();
-
-         Assert.IsType<InvalidOperationException>(otherThreadException);
-
-         // The mismatched Dispose() must not have decremented the creating thread's counter: it
-         // is still active here and must be disposed on this (the creating) thread to clean up.
-         Assert.True(WeakEventSource.NotificationsSuppressed);
-         scope.Dispose();
-         Assert.False(WeakEventSource.NotificationsSuppressed);
-      }
+      // There is deliberately no "dispose on a different thread" test: SuppressionScope is a `ref
+      // struct`, so the compiler itself forbids capturing it in a lambda/closure (e.g. the body of
+      // `new Thread(() => scope.Dispose())` below would not compile), storing it in a field, or
+      // using it across an `await`. Cross-thread misuse of the scope is therefore a compile-time
+      // error, not something that can be exercised or asserted on at runtime.
    }
 }

--- a/tests/QLNet.Tests/T_WeakEventSourceSuppression.cs
+++ b/tests/QLNet.Tests/T_WeakEventSourceSuppression.cs
@@ -1,0 +1,193 @@
+/*
+ Copyright (C) 2008-2026  Andrea Maggiulli (a.maggiulli@gmail.com)
+
+ This file is part of QLNet Project https://github.com/amaggiulli/qlnet
+
+ QLNet is free software: you can redistribute it and/or modify it
+ under the terms of the QLNet license.  You should have received a
+ copy of the license along with this program; if not, license is
+ available at <https://github.com/amaggiulli/QLNet/blob/develop/LICENSE>.
+
+ QLNet is a based on QuantLib, a free-software/open-source library
+ for financial quantitative analysts and developers - http://quantlib.org/
+ The QuantLib license is available online at http://quantlib.org/license.shtml.
+
+ This program is distributed in the hope that it will be useful, but WITHOUT
+ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ FOR A PARTICULAR PURPOSE.  See the license for more details.
+*/
+using System;
+using System.Threading;
+using Xunit;
+using QLNet;
+
+namespace TestSuite
+{
+   [Collection("QLNet CI Tests")]
+   public class T_WeakEventSourceSuppression
+   {
+      // Kept as an instance (non-static) handler target so WeakEventSource wraps it in a real
+      // WeakReference; the local variable in each test keeps it alive for the test's duration.
+      private class Counter
+      {
+         public int Count;
+         public void Increment() { Count++; }
+      }
+
+      [Fact]
+      public void SuppressNotifications_SuppressesSubscribeRaiseAndUnsubscribe()
+      {
+         var source = new WeakEventSource();
+         var counter = new Counter();
+
+         using (WeakEventSource.SuppressNotifications())
+         {
+            // Subscribe should be a no-op inside the scope.
+            source.Subscribe(counter.Increment);
+            // Raise should be a no-op inside the scope, even if a handler were registered.
+            source.Raise();
+         }
+
+         Assert.Equal(0, counter.Count);
+
+         // Outside the scope, Raise now works normally, but since Subscribe was suppressed while
+         // the scope was active, the handler was never actually added: nothing should fire.
+         source.Raise();
+         Assert.Equal(0, counter.Count);
+
+         // Subscribe for real, outside any suppression scope.
+         source.Subscribe(counter.Increment);
+         source.Raise();
+         Assert.Equal(1, counter.Count);
+
+         using (WeakEventSource.SuppressNotifications())
+         {
+            // Unsubscribe should be a no-op inside the scope: the handler must remain registered.
+            source.Unsubscribe(counter.Increment);
+         }
+
+         source.Raise();
+         Assert.Equal(2, counter.Count);
+      }
+
+      [Fact]
+      public void SuppressNotifications_NestedScopesComposeViaDepthCounter()
+      {
+         Assert.False(WeakEventSource.NotificationsSuppressed);
+
+         var outer = WeakEventSource.SuppressNotifications();
+         Assert.True(WeakEventSource.NotificationsSuppressed);
+
+         var inner = WeakEventSource.SuppressNotifications();
+         Assert.True(WeakEventSource.NotificationsSuppressed);
+
+         inner.Dispose();
+         // The outer scope is still active: notifications must remain suppressed until it, too,
+         // is disposed (depth-counter semantics, not a simple bool).
+         Assert.True(WeakEventSource.NotificationsSuppressed);
+
+         outer.Dispose();
+         Assert.False(WeakEventSource.NotificationsSuppressed);
+      }
+
+      [Fact]
+      public void SuppressNotifications_DisposingTwiceIsIdempotentAndDoesNotUnderflow()
+      {
+         var scope = WeakEventSource.SuppressNotifications();
+         Assert.True(WeakEventSource.NotificationsSuppressed);
+
+         scope.Dispose();
+         Assert.False(WeakEventSource.NotificationsSuppressed);
+
+         // A second Dispose() call must be a safe no-op (standard IDisposable contract), and must
+         // not decrement _suppressionDepth a second time (which would trigger the underflow guard
+         // on a subsequent, unrelated SuppressNotifications()/Dispose() pair on this thread).
+         scope.Dispose();
+         Assert.False(WeakEventSource.NotificationsSuppressed);
+
+         using (WeakEventSource.SuppressNotifications())
+         {
+            Assert.True(WeakEventSource.NotificationsSuppressed);
+         }
+
+         Assert.False(WeakEventSource.NotificationsSuppressed);
+      }
+
+      [Fact]
+      public void SuppressNotifications_IsThreadLocal_OtherThreadsAreUnaffected()
+      {
+         var source = new WeakEventSource();
+         var counter = new Counter();
+         source.Subscribe(counter.Increment);
+
+         using var suppressionEntered = new ManualResetEventSlim(false);
+         using var releaseOtherThread = new ManualResetEventSlim(false);
+         Exception otherThreadException = null;
+
+         var otherThread = new Thread(() =>
+         {
+            try
+            {
+               // Wait until the main thread has entered its suppression scope before raising, so
+               // this genuinely exercises "another thread while suppression is active elsewhere".
+               suppressionEntered.Wait();
+               Assert.False(WeakEventSource.NotificationsSuppressed);
+               source.Raise();
+            }
+            catch (Exception ex)
+            {
+               otherThreadException = ex;
+            }
+            finally
+            {
+               releaseOtherThread.Set();
+            }
+         });
+         otherThread.IsBackground = true;
+         otherThread.Start();
+
+         using (WeakEventSource.SuppressNotifications())
+         {
+            Assert.True(WeakEventSource.NotificationsSuppressed);
+            suppressionEntered.Set();
+            releaseOtherThread.Wait();
+         }
+
+         otherThread.Join();
+
+         Assert.Null(otherThreadException);
+         // The other thread was never suppressed, so its Raise() must have invoked the handler.
+         Assert.Equal(1, counter.Count);
+      }
+
+      [Fact]
+      public void SuppressNotifications_DisposingOnADifferentThreadThrows()
+      {
+         var scope = WeakEventSource.SuppressNotifications();
+         Exception otherThreadException = null;
+
+         var otherThread = new Thread(() =>
+         {
+            try
+            {
+               scope.Dispose();
+            }
+            catch (Exception ex)
+            {
+               otherThreadException = ex;
+            }
+         });
+         otherThread.IsBackground = true;
+         otherThread.Start();
+         otherThread.Join();
+
+         Assert.IsType<InvalidOperationException>(otherThreadException);
+
+         // The mismatched Dispose() must not have decremented the creating thread's counter: it
+         // is still active here and must be disposed on this (the creating) thread to clean up.
+         Assert.True(WeakEventSource.NotificationsSuppressed);
+         scope.Dispose();
+         Assert.False(WeakEventSource.NotificationsSuppressed);
+      }
+   }
+}

--- a/tests/QLNet.Tests/T_WeakEventSourceSuppression.cs
+++ b/tests/QLNet.Tests/T_WeakEventSourceSuppression.cs
@@ -76,17 +76,33 @@ namespace TestSuite
          Assert.False(WeakEventSource.NotificationsSuppressed);
 
          var outer = WeakEventSource.SuppressNotifications();
-         Assert.True(WeakEventSource.NotificationsSuppressed);
+         try
+         {
+            Assert.True(WeakEventSource.NotificationsSuppressed);
 
-         var inner = WeakEventSource.SuppressNotifications();
-         Assert.True(WeakEventSource.NotificationsSuppressed);
+            var inner = WeakEventSource.SuppressNotifications();
+            try
+            {
+               Assert.True(WeakEventSource.NotificationsSuppressed);
+            }
+            finally
+            {
+               inner.Dispose();
+            }
 
-         inner.Dispose();
-         // The outer scope is still active: notifications must remain suppressed until it, too,
-         // is disposed (depth-counter semantics, not a simple bool).
-         Assert.True(WeakEventSource.NotificationsSuppressed);
+            // The outer scope is still active: notifications must remain suppressed until it, too,
+            // is disposed (depth-counter semantics, not a simple bool).
+            Assert.True(WeakEventSource.NotificationsSuppressed);
+         }
+         finally
+         {
+            // Guarantees cleanup (and thus test isolation on this [ThreadStatic] state) even if one
+            // of the assertions above throws before the explicit Dispose() calls below would run.
+            // Dispose() is idempotent, so this is a safe no-op on the success path where outer/inner
+            // were already disposed as part of the assertions they were guarding.
+            outer.Dispose();
+         }
 
-         outer.Dispose();
          Assert.False(WeakEventSource.NotificationsSuppressed);
       }
 
@@ -94,9 +110,17 @@ namespace TestSuite
       public void SuppressNotifications_DisposingTwiceIsIdempotentAndDoesNotUnderflow()
       {
          var scope = WeakEventSource.SuppressNotifications();
-         Assert.True(WeakEventSource.NotificationsSuppressed);
+         try
+         {
+            Assert.True(WeakEventSource.NotificationsSuppressed);
+         }
+         finally
+         {
+            // Guarantees cleanup even if the assertion above throws, so suppression state can't leak
+            // to other tests sharing this thread.
+            scope.Dispose();
+         }
 
-         scope.Dispose();
          Assert.False(WeakEventSource.NotificationsSuppressed);
 
          // A second Dispose() call must be a safe no-op: this API is explicitly designed to be
@@ -108,6 +132,31 @@ namespace TestSuite
 
          using (WeakEventSource.SuppressNotifications())
          {
+            Assert.True(WeakEventSource.NotificationsSuppressed);
+         }
+
+         Assert.False(WeakEventSource.NotificationsSuppressed);
+      }
+
+      [Fact]
+      public void DefaultSuppressionScope_DisposeIsANoOpAndDoesNotTouchSuppressionDepth()
+      {
+         Assert.False(WeakEventSource.NotificationsSuppressed);
+
+         // default(SuppressionScope) bypasses SuppressNotifications() entirely (e.g. a field or local
+         // never assigned), so it never incremented _suppressionDepth. Disposing it must be a no-op:
+         // it must not decrement _suppressionDepth (which would otherwise falsely suppress/underflow),
+         // regardless of whether another, real scope happens to be active on this thread at the time.
+         default(WeakEventSource.SuppressionScope).Dispose();
+         Assert.False(WeakEventSource.NotificationsSuppressed);
+
+         using (WeakEventSource.SuppressNotifications())
+         {
+            Assert.True(WeakEventSource.NotificationsSuppressed);
+
+            default(WeakEventSource.SuppressionScope).Dispose();
+
+            // The real, active scope above must be unaffected by disposing an unrelated default value.
             Assert.True(WeakEventSource.NotificationsSuppressed);
          }
 

--- a/tests/QLNet.Tests/T_WeakEventSourceSuppression.cs
+++ b/tests/QLNet.Tests/T_WeakEventSourceSuppression.cs
@@ -44,7 +44,9 @@ namespace TestSuite
          {
             // Subscribe should be a no-op inside the scope.
             source.Subscribe(counter.Increment);
-            // Raise should be a no-op inside the scope, even if a handler were registered.
+            // No handler is registered yet at this point (the Subscribe() above was itself
+            // suppressed), so this call alone doesn't prove Raise() suppression - that is verified
+            // further down with a genuinely registered handler.
             source.Raise();
          }
 
@@ -58,6 +60,15 @@ namespace TestSuite
          // Subscribe for real, outside any suppression scope.
          source.Subscribe(counter.Increment);
          source.Raise();
+         Assert.Equal(1, counter.Count);
+
+         using (WeakEventSource.SuppressNotifications())
+         {
+            // With a real handler registered, Raise() must genuinely be suppressed here: without the
+            // suppression check, this call would increment counter, which the assertion below rules out.
+            source.Raise();
+         }
+
          Assert.Equal(1, counter.Count);
 
          using (WeakEventSource.SuppressNotifications())


### PR DESCRIPTION
This pull request introduces a thread-local notification suppression mechanism to the `WeakEventSource` class, allowing callers to temporarily disable all event notifications and related overhead on a per-thread basis. This is especially useful for scenarios involving large numbers of short-lived observer graphs, improving performance by eliminating unnecessary notification logic when it's not needed.